### PR TITLE
feat: add Community Edition operations desk

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,7 +4,7 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 receipt="$(git config --worktree --get-regexp 'deliveryTargetReceipt$' 2>/dev/null | awk 'NR == 1 { print $2 }')"
-validator="$(git config --worktree --get deliveryTargetValidator || true)"
+validator="$(git config --worktree --get-regexp 'deliveryTargetValidator$' 2>/dev/null | awk 'NR == 1 { print $2 }')"
 
 if [[ -z "$receipt" || -z "$validator" ]]; then
   echo "status=FAIL condition=missing_delivery_target_configuration" >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Validate an explicitly configured receipt before a guarded release push.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+receipt="$(git config --worktree --get-regexp 'deliveryTargetReceipt$' 2>/dev/null | awk 'NR == 1 { print $2 }')"
+validator="$(git config --worktree --get deliveryTargetValidator || true)"
+
+if [[ -z "$receipt" || -z "$validator" ]]; then
+  echo "status=FAIL condition=missing_delivery_target_configuration" >&2
+  exit 1
+fi
+
+if [[ ! -f "$validator" ]]; then
+  echo "status=FAIL condition=missing_delivery_target_validator" >&2
+  exit 1
+fi
+
+exec python3 "$validator" \
+  --receipt "$receipt" \
+  --repo-root "$repo_root" \
+  --pre-push-stdin

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Validation
+
+List the checks you ran.
+
+## Contributor and License Confirmation
+
+- [ ] I have read and agree to the [Contributor License Agreement](../CLA.md).
+- [ ] I have the right to submit this contribution under the CLA terms.
+- [ ] I understand that Community Edition is noncommercial and source-available, and that the maintainer may offer separate commercial licenses.
+- [ ] This contribution contains no real personal, confidential, or third-party proprietary data.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
         name: Verify extension brand boundaries
       - run: python3 scripts/verify_no_turkish.py --path .
         name: Verify public-facing language
+      - run: python3 scripts/check_license_policy.py
+        name: Verify noncommercial license boundary
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,106 +6,65 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  lint:
-    name: Markdown Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-      - run: npx --yes markdownlint-cli2 "**/*.md" "#node_modules"
-
-  pii-scan:
-    name: PII Scan
+  python:
+    name: Python, dashboard, and privacy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-      - run: python3 scripts/scan_pii.py --path .
-        name: Scan for personal data leaks
-
-  python-check:
-    name: Python Syntax Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: |
-          python3 -m py_compile scripts/scan_pii.py
-          python3 -m py_compile scripts/validate_pdf_standard.py
-          python3 -m py_compile scripts/check_secret_hygiene.py
-          python3 -m py_compile scripts/job_dashboard.py
-          python3 -m py_compile scripts/md_to_tex.py
-          python3 -m py_compile scripts/md_to_docx.py
-          python3 -m py_compile scripts/verify_no_turkish.py
-          python3 -m py_compile scripts/relocation_livability_research.py
-        name: Verify Python scripts compile
-
-  test:
-    name: Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: pip install fastapi pydantic pyyaml uvicorn httpx pytest
-      - run: pytest --tb=short -q
-
-  setup-script-test:
-    name: Setup Script Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: pip install pytest
-      - run: bash -n scripts/setup.sh
-        name: Bash syntax check
-      - run: pytest tests/test_setup.py -v --tb=short
-        name: Setup behavior tests
-
-  dashboard-smoke:
-    name: Dashboard Smoke Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: pip install fastapi uvicorn jinja2 markdown pyyaml httpx
+          python-version: "3.12"
+      - run: python3 -m pip install --upgrade pip
+      - run: python3 -m pip install -e ".[dashboard,dev]"
+      - run: python3 -m compileall -q dashboard scripts tests
+        name: Compile Python sources
+      - run: python3 -m pytest -q
+        name: Run Python tests
       - run: PYTHONPATH=scripts python3 -m jsw smoke
-        name: Dashboard smoke test
-
-  turkish-check:
-    name: Turkish Content Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+        name: Run dashboard smoke test
+      - run: python3 scripts/scan_pii.py --path .
+        name: Scan the complete public tree
+      - run: python3 scripts/check_secret_hygiene.py
+        name: Scan for common secret formats
+      - run: python3 scripts/check_linkedin_brand.py
+        name: Verify extension brand boundaries
       - run: python3 scripts/verify_no_turkish.py --path .
-        name: Verify no Turkish content in public-facing files
+        name: Verify public-facing language
 
-  extension-lint:
-    name: Browser Extension Lint & Test
+  docs:
+    name: Documentation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - working-directory: tools/browser-extension
-        run: npm install
-      - working-directory: tools/browser-extension
-        run: npm run lint
-      - working-directory: tools/browser-extension
-        run: npm test
+      - run: npx --yes markdownlint-cli2@0.20.0 "**/*.md" "#**/node_modules/**"
+        name: Lint Markdown
+
+  extension:
+    name: Browser extension
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/browser-extension
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: tools/browser-extension/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: node scripts/validate-manifest.js
+      - run: npm test -- --runInBand
+      - run: npm audit --audit-level=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - run: python3 -m pip install -e ".[dashboard,dev]"
       - run: python3 -m compileall -q dashboard scripts tests
         name: Compile Python sources
+      - run: python3 -m ruff check dashboard scripts tests
+        name: Lint Python sources
       - run: python3 -m pytest -q
         name: Run Python tests
       - run: PYTHONPATH=scripts python3 -m jsw smoke

--- a/.github/workflows/setup-audit.yml
+++ b/.github/workflows/setup-audit.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: "22"
       - run: python3 -m pip install -e ".[dashboard,dev]"
-      - run: sudo apt-get update && sudo apt-get install --yes shellcheck
+      - run: shellcheck --version
       - run: bash -n scripts/setup.sh
       - run: shellcheck scripts/setup.sh
       - run: python3 -m unittest discover -s tests -v

--- a/.github/workflows/setup-audit.yml
+++ b/.github/workflows/setup-audit.yml
@@ -1,135 +1,45 @@
 name: Setup Audit
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: "0 6 * * 1"
 
 permissions:
   contents: read
 
 jobs:
   linux:
-    name: Linux setup and tests
+    name: Linux setup contract
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-
-      - name: Install audit tools
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes shellcheck
-          python3 -m pip install fastapi pydantic pyyaml uvicorn httpx pytest
-          npm install --global markdownlint-cli2@0.20.0
-
-      - name: Static checks
-        run: |
-          bash -n scripts/setup.sh
-          shellcheck scripts/setup.sh
-          markdownlint-cli2 "**/*.md"
-
-      - name: Behavior tests
-        run: python3 -m unittest discover -s tests -v
-
-      - name: Full setup smoke test
-        run: ./scripts/setup.sh
-
-  extension:
-    name: Browser extension lint, test and manifest validation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install extension dependencies
-        run: |
-          cd tools/browser-extension
-          npm ci
-
-      - name: Extension static checks
-        run: |
-          cd tools/browser-extension
-          npm run lint
-          node scripts/validate-manifest.js
-
-      - name: Extension unit and DOM tests
-        run: |
-          cd tools/browser-extension
-          npm test
-
-      - name: PII / private-reference scan
-        run: python3 scripts/scan_pii.py
-
-      - name: LinkedIn brand check
-        run: python3 scripts/check_linkedin_brand.py
-
-  capture-server:
-    name: Capture server Python tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: Install Python dependencies
-        run: |
-          python3 -m pip install fastapi pydantic pyyaml uvicorn httpx pytest
-
-      - name: Run capture server tests
-        run: python3 -m pytest tests/test_linkedin_capture_server.py -q
-
-      - name: Python compile check
-        run: |
-          python3 -m py_compile scripts/linkedin_capture_server.py
-          python3 -m py_compile scripts/scan_pii.py
-          python3 -m py_compile scripts/check_linkedin_brand.py
+          node-version: "22"
+      - run: python3 -m pip install -e ".[dashboard,dev]"
+      - run: sudo apt-get update && sudo apt-get install --yes shellcheck
+      - run: bash -n scripts/setup.sh
+      - run: shellcheck scripts/setup.sh
+      - run: python3 -m unittest discover -s tests -v
+      - run: ./scripts/setup.sh --check-only
+      - run: ./scripts/setup.sh
 
   windows:
-    name: Windows setup smoke test
+    name: Windows setup contract
     runs-on: windows-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-
-      - name: Full setup smoke test
-        shell: cmd
+          node-version: "22"
+      - shell: cmd
+        run: scripts\setup.bat --check-only
+      - shell: cmd
         run: scripts\setup.bat

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,5 +1,8 @@
 # markdownlint-cli2 config for job-search-workflow public repository
 # Prompt files, fixtures, and templates intentionally relax strict prose rules.
+ignores:
+  - "**/node_modules/**"
+
 config:
   default: true
   MD013: false  # line length

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Edition.
 - Fixed Python quality defects in the Markdown-to-LaTeX and language-checking
   utilities.
 - Corrected setup fixture initialization and broken documentation links.
+- Removed the hosted Linux setup audit's redundant package-mirror dependency.
 - Removed raw frontmatter metadata from rendered job-detail content.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+This file records user-visible changes to Job Search Workflow Community
+Edition. No stable release or tag is represented by the entries below.
+
+## [Unreleased] - 2026-08-19
+
+### Added
+
+- Community Operations Desk with overview, pipeline, jobs, profile, and scoring
+  views for local Markdown workspaces.
+- Read-only workflow guards for duplicate detection, field limits, lifecycle
+  checks, and configurable eligibility rules.
+- Profile direction cards for target roles, must-haves, preferences, and avoid
+  signals.
+- Installable `jsw` command with local initialization, dashboard, and smoke
+  checks.
+
+### Changed
+
+- Renamed the public user surface to Job Search Workflow Community Edition and
+  the dashboard to Community Operations Desk.
+- Adopted a light-first, responsive interface with optional dark mode and
+  compact component radii.
+- Consolidated pull-request checks for Python, documentation, privacy, and the
+  browser extension.
+- Clarified that Community Edition is source-available for noncommercial use
+  and separate from the owner-operated commercial SaaS.
+
+### Fixed
+
+- Expanded PII scanning to the selected public tree and added regression tests.
+- Corrected stale setup, workflow, package, extension, and release instructions.
+- Fixed Python quality defects in the Markdown-to-LaTeX and language-checking
+  utilities.
+- Corrected setup fixture initialization and broken documentation links.
+
+### Security
+
+- Added secret, brand, language, and deterministic license-policy checks.
+- Replaced inconsistent first-party license metadata with the official
+  PolyForm Noncommercial 1.0.0 boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Edition. No stable release or tag is represented by the entries below.
 - Installable `jsw` command with local initialization, dashboard, and smoke
   checks.
 - Persistent dashboard ownership and noncommercial-use notice.
+- Posting-specific access to existing CV, cover-letter, and application-answer
+  files, plus a richer fictitious pipeline for local demonstrations.
+- Direct GitHub Sponsors access from the Community Edition overview.
 
 ### Changed
 
@@ -23,6 +26,10 @@ Edition. No stable release or tag is represented by the entries below.
   the dashboard to Community Operations Desk.
 - Adopted a light-first, responsive interface with optional dark mode and
   compact component radii.
+- Replaced numeric-only quality-risk penalties with plain-language score
+  explanations and an example calculation.
+- Moved posting-specific application files into a responsive right rail on
+  wide screens while preserving the single-column narrow layout.
 - Consolidated pull-request checks for Python, documentation, privacy, and the
   browser extension.
 - Clarified that Community Edition is source-available for noncommercial use
@@ -35,6 +42,7 @@ Edition. No stable release or tag is represented by the entries below.
 - Fixed Python quality defects in the Markdown-to-LaTeX and language-checking
   utilities.
 - Corrected setup fixture initialization and broken documentation links.
+- Removed raw frontmatter metadata from rendered job-detail content.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,5 +47,7 @@ Edition.
 ### Security
 
 - Added secret, brand, language, and deterministic license-policy checks.
+- Added an opt-in, receipt-bound pre-push entry point for guarded release
+  delivery.
 - Replaced inconsistent first-party license metadata with the official
   PolyForm Noncommercial 1.0.0 boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Edition. No stable release or tag is represented by the entries below.
   signals.
 - Installable `jsw` command with local initialization, dashboard, and smoke
   checks.
+- Persistent dashboard ownership and noncommercial-use notice.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 This file records user-visible changes to Job Search Workflow Community
-Edition. No stable release or tag is represented by the entries below.
+Edition.
 
-## [Unreleased] - 2026-08-19
+## [0.1.0] - 2026-08-19
 
 ### Added
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,11 +1,14 @@
 # Contributor License Agreement (CLA)
 
+Version 1.1, effective 2026-08-19.
+
 By contributing to the **job-search-workflow** project, you agree to the
 following terms.
 
 ## 1. Definitions
 
-- **"Project"** means the job-search-workflow open-source project.
+- **"Project"** means the Job Search Workflow Community Edition source-available
+  project.
 - **"Contributor"** means the individual submitting a contribution.
 - **"Contribution"** means any original work of authorship, including
   modifications, additions, or new files, submitted to the Project.
@@ -18,6 +21,12 @@ no-charge, royalty-free, irrevocable copyright license to reproduce,
 prepare derivative works of, publicly display, publicly perform,
 sublicense, and distribute Contributor's Contributions and such
 derivative works.
+
+This grant includes the right for Maintainer to license or relicense a
+Contribution, alone or as part of the Project, under the Project's public
+noncommercial license and under separate commercial license terms. Contributor
+retains copyright in the Contribution. No separate permission or royalty is
+required for Maintainer to exercise the rights granted in this section.
 
 ## 3. Grant of Patent License
 
@@ -49,6 +58,10 @@ permission.
 
 The Project is licensed under the PolyForm Noncommercial 1.0.0 license.
 Contributor's Contributions are licensed under the same terms.
+
+Public availability under PolyForm Noncommercial does not prevent Maintainer
+from offering the Project, Contributions, or derivative works under separate
+commercial license terms.
 
 ## 7. No Warranty
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,8 +30,10 @@ Examples of unacceptable behavior:
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainers. All complaints will be reviewed and
-investigated promptly and fairly.
+reported to the project owner through the maintainer's GitHub profile. Request
+a private contact channel and do not publish sensitive details in an issue. All
+complaints will be reviewed and investigated fairly; no response-time
+commitment is currently offered.
 
 ## Attribution
 

--- a/COMMERCIAL_USE.md
+++ b/COMMERCIAL_USE.md
@@ -1,0 +1,55 @@
+# Commercial Use and SaaS Boundary
+
+## License Status
+
+Job Search Workflow Community Edition is source-available software licensed
+under the [PolyForm Noncommercial License 1.0.0](LICENSE). It is not distributed
+under an OSI-approved open-source license.
+
+The `LICENSE` file is the complete public license grant. This document explains
+the project owner's intended product boundary but does not replace, expand, or
+reduce the license. If this summary conflicts with `LICENSE`, the license
+controls.
+
+## Commercial Use
+
+The public repository does not grant a commercial-use license. Obtain a
+separate written agreement from the copyright holder before using Community
+Edition code for commercial advantage or monetary compensation.
+
+Treat activities such as offering a hosted or paid service, selling access,
+bundling the code into a commercial product, or charging for code-based
+customization as requiring prior written permission. This list is illustrative,
+not a replacement for the license terms or independent legal advice.
+
+There is no automatic commercial license, reseller right, or commercial SaaS
+right available through cloning, forking, contributing to, or redistributing
+this repository.
+
+## Owner-Operated SaaS
+
+The owner's commercial SaaS product is a separate product and repository. It is
+not included in Community Edition. Access to this repository does not grant
+rights to private SaaS source code, hosted infrastructure, customer data,
+private product assets, deployment configuration, or non-public services.
+
+## Brand Boundary
+
+The software license does not grant permission to present a fork, hosted
+service, or commercial product as the official Job Search Workflow product or
+as endorsed by the project owner. Forks should use their own product name and
+branding unless they have separate written permission.
+
+## Commercial Licensing Requests
+
+No commercial license is offered automatically. Requests must be reviewed and
+accepted in a separate written agreement by the copyright holder. Use the
+repository's GitHub owner contact surface for an initial licensing inquiry; do
+not post confidential business information in a public issue.
+
+## Historical Versions
+
+License changes apply prospectively to the versions where they appear. They do
+not withdraw rights that may already have been validly granted for an earlier
+version. Consult qualified legal counsel before relying on historical metadata
+or making a commercial-use determination.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,9 @@ structured, honest, and reusable framework for AI-assisted job searching.
 2. Follow existing code style and conventions.
 3. Ensure all CI checks pass (`markdownlint`, `pytest`, PII scan).
 4. Write or update tests for new functionality.
-5. Keep PRs focused — one logical change per PR.
+5. Complete every contributor and license confirmation in the pull request
+   template.
+6. Keep PRs focused - one logical change per PR.
 
 ### What We Welcome
 
@@ -63,4 +65,8 @@ Be respectful, constructive, and inclusive.
 ## License
 
 By contributing, you agree that your contributions will be licensed under the
-[PolyForm Noncommercial 1.0.0](LICENSE) license.
+[PolyForm Noncommercial 1.0.0](LICENSE) license and that the
+[Contributor License Agreement](CLA.md) applies. The CLA allows the maintainer
+to offer separate commercial licenses while Community Edition remains
+noncommercial and source-available. Review
+[Commercial Use and SaaS Boundary](COMMERCIAL_USE.md) before contributing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to job-search-workflow
+# Contributing to Job Search Workflow Community Edition
 
 Thank you for your interest in contributing! This project aims to provide a
 structured, honest, and reusable framework for AI-assisted job searching.
@@ -9,7 +9,8 @@ structured, honest, and reusable framework for AI-assisted job searching.
 
 - Use GitHub Issues for bug reports, feature requests, or documentation gaps.
 - Include steps to reproduce for bugs.
-- For security vulnerabilities, please email instead of opening a public issue.
+- Follow [SECURITY.md](SECURITY.md) for private-first vulnerability reporting;
+  do not put exploit details or secrets in a public issue.
 
 ### Pull Requests
 
@@ -27,14 +28,15 @@ structured, honest, and reusable framework for AI-assisted job searching.
 - Script enhancements (validation, export, automation)
 - Sample fixtures (fictitious profiles, postings, CVs)
 - Documentation clarity improvements
-- Translations of modes/runbooks
+- English documentation and accessibility improvements
 - CI/CD pipeline improvements
 
 ### What We Don't Accept
 
 - Real personal data in any form (names, emails, companies, dates)
-- Auto-apply or scraping functionality
-- Bypassing login walls, rate limits, or access controls
+- Automated application submission or credential extraction
+- Bulk scraping or bypassing login walls, rate limits, bot challenges, or
+  access controls
 - Dependencies on proprietary SaaS backends
 
 ## Development Standards

--- a/LICENSE
+++ b/LICENSE
@@ -1,45 +1,131 @@
-PolyForm Noncommercial License 1.0.0
+# PolyForm Noncommercial License 1.0.0
 
 <https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Copyright (c) 2026 Orcun Sener
+## Acceptance
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
 
-1. The Software may be used only for Noncommercial Purposes. "Noncommercial
-   Purposes" means any purpose that does not constitute "Commercial Use" as
-   defined below.
+## Copyright License
 
-2. "Commercial Use" means any use of the Software that is primarily intended
-   for or directed toward commercial advantage or monetary compensation.
-   Examples of Commercial Use include: using the Software as part of a paid
-   service or product; using the Software internally within a business to
-   generate revenue; selling copies of the Software; or using the Software to
-   provide consulting or services for a fee.
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
 
-3. The following are not Commercial Use:
-   - Personal learning, education, and research
-   - Non-commercial open-source projects
-   - Job searching by individuals for their own employment
-   - Use by non-profit organizations, universities, and educational
-     institutions for non-revenue-generating purposes
-   - Internal use by a business for its own hiring (not as a product or
-     service sold to others)
+## Distribution License
 
-4. Redistributions of the Software must retain this license and copyright
-   notice.
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
 
-5. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-   DEALINGS IN THE SOFTWARE.
+## Notices
 
-SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,2 @@
+Required Notice: Copyright 2026 Orcun Sener
+SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0

--- a/PUBLISH_CHECKLIST_EXTENSION.md
+++ b/PUBLISH_CHECKLIST_EXTENSION.md
@@ -11,13 +11,14 @@ owner-specific defaults, English-only public UI, and release approvals.
 
 ## Pre-release verification
 
-- [ ] `tools/browser-extension/npm test` passes with **147/147** tests.
-- [ ] `tools/browser-extension/npm run lint` passes.
-- [ ] `tools/browser-extension/node scripts/validate-manifest.js` passes.
-- [ ] `python3 -m pytest public/tests/test_linkedin_capture_server.py -q` passes.
-- [ ] `python3 -m py_compile public/scripts/linkedin_capture_server.py` passes.
-- [ ] `python3 public/scripts/scan_pii.py` passes.
-- [ ] `python3 public/scripts/check_linkedin_brand.py` passes.
+- [ ] `npm test` passes from `tools/browser-extension/`.
+- [ ] `npm run lint` passes from `tools/browser-extension/`.
+- [ ] `node scripts/validate-manifest.js` passes from `tools/browser-extension/`.
+- [ ] `npm audit --audit-level=high` reports no high or critical findings.
+- [ ] `python3 -m pytest tests/test_linkedin_capture_server.py -q` passes.
+- [ ] `python3 -m py_compile scripts/linkedin_capture_server.py` passes.
+- [ ] `python3 scripts/scan_pii.py --path .` passes.
+- [ ] `python3 scripts/check_linkedin_brand.py` passes.
 - [ ] `npx markdownlint-cli2 "**/*.md"` passes.
 - [ ] `.github/workflows/clone-scan.yml` YAML is valid.
 

--- a/PUBLISH_CHECKLIST_EXTENSION.md
+++ b/PUBLISH_CHECKLIST_EXTENSION.md
@@ -36,6 +36,8 @@ zip -r ../../job-search-workflow-capture-v2.0.0.zip \
   content/ utils/ scripts/ tests/ \
   package.json package-lock.json jest.config.js .eslintrc.json \
   -x "node_modules/*" -x "coverage/*" -x "*.log"
+zip -j ../../job-search-workflow-capture-v2.0.0.zip \
+  ../../LICENSE ../../NOTICE ../../COMMERCIAL_USE.md
 ```
 
 Verify the `.zip` contents:
@@ -56,6 +58,7 @@ The archive must contain at minimum:
 - `utils/*.js`
 - `scripts/validate-manifest.js`
 - `readme.md`
+- `LICENSE`, `NOTICE`, and `COMMERCIAL_USE.md`
 
 ## Create the GitHub release
 

--- a/PUBLISH_CHECKLIST_EXTENSION.md
+++ b/PUBLISH_CHECKLIST_EXTENSION.md
@@ -18,9 +18,13 @@ owner-specific defaults, English-only public UI, and release approvals.
 - [ ] `python3 -m pytest tests/test_linkedin_capture_server.py -q` passes.
 - [ ] `python3 -m py_compile scripts/linkedin_capture_server.py` passes.
 - [ ] `python3 scripts/scan_pii.py --path .` passes.
+- [ ] `python3 scripts/check_secret_hygiene.py` passes.
 - [ ] `python3 scripts/check_linkedin_brand.py` passes.
+- [ ] `python3 scripts/verify_no_turkish.py --path .` passes.
+- [ ] `python3 scripts/check_license_policy.py` passes.
 - [ ] `npx markdownlint-cli2 "**/*.md"` passes.
-- [ ] `.github/workflows/clone-scan.yml` YAML is valid.
+- [ ] `.github/workflows/ci.yml` and `.github/workflows/setup-audit.yml` pass
+  `actionlint`.
 
 ## Build the Phase 1 load-unpacked `.zip`
 
@@ -33,8 +37,7 @@ zip -r ../../job-search-workflow-capture-v2.0.0.zip \
   manifest.json popup.html popup.js popup.css \
   options.html options.js options.css \
   service_worker.js icon.png readme.md \
-  content/ utils/ scripts/ tests/ \
-  package.json package-lock.json jest.config.js .eslintrc.json \
+  content/ utils/ \
   -x "node_modules/*" -x "coverage/*" -x "*.log"
 zip -j ../../job-search-workflow-capture-v2.0.0.zip \
   ../../LICENSE ../../NOTICE ../../COMMERCIAL_USE.md
@@ -63,10 +66,11 @@ The archive must contain at minimum:
 ## Create the GitHub release
 
 1. Ensure the working tree is clean and the checklist above is complete.
-2. Create a tag, for example `extension-v2.0.0`.
-3. Create a GitHub release using that tag.
-4. Attach `job-search-workflow-capture-v2.0.0.zip` to the release.
-5. Include installation instructions and a link to
+2. Obtain explicit owner approval for the tag and public release.
+3. Create a tag, for example `extension-v2.0.0`.
+4. Create a GitHub release using that tag.
+5. Attach `job-search-workflow-capture-v2.0.0.zip` to the release.
+6. Include installation instructions and a link to
    `docs/runbooks/browser-extension-install.md`.
 
 ## Post-release

--- a/README.md
+++ b/README.md
@@ -135,12 +135,19 @@ Open `http://localhost:3000` to use:
 - a local workspace overview and attention list
 - a responsive application pipeline
 - searchable job records with compact dates
+- posting-specific CV, cover-letter, and application-answer access
 - profile, career-direction, decision-criteria, and scoring reference views
 - a light-first interface with an optional dark theme
 
 The dashboard is read-only and does not require an account or external data
 transfer. `scripts/job_dashboard.py` is retained as a legacy compatibility
 entry point; `python3 -m jsw dashboard` is the canonical interface.
+
+To surface application documents for a job, place them under
+`exports/applications/<posting-filename-without-.md>/`. The dashboard admits
+only CV/resume, cover-letter, and application-answer files with `.md`, `.txt`,
+`.pdf`, or `.docx` extensions. LaTeX sources, triage notes, research, and other
+preparation files are intentionally excluded.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Open `http://localhost:3000` to use:
 - a local workspace overview and attention list
 - a responsive application pipeline
 - searchable job records with compact dates
-- profile and scoring reference views
+- profile, career-direction, decision-criteria, and scoring reference views
 - a light-first interface with an optional dark theme
 
 The dashboard is read-only and does not require an account or external data

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 > Status: Alpha. The Community Edition is cloneable and locally testable, but
 > interfaces may still change before a stable release.
+>
+> License: source-available for noncommercial use under PolyForm Noncommercial
+> 1.0.0. Commercial use is not granted by this repository. See
+> [Commercial Use and SaaS Boundary](COMMERCIAL_USE.md).
 
 Job Search Workflow Community Edition is a reusable, local-first framework for
 job triage, document-generation standards, application tracking, and public

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# Job Search Workflow Public Framework
+# Job Search Workflow Community Edition
 
-> Status: Preparing for public release. This directory is not yet an independent, publication-ready public repository.
+> Status: Alpha. The Community Edition is cloneable and locally testable, but
+> interfaces may still change before a stable release.
 
-Job Search Workflow is intended to become a reusable framework that contains no personal data. It is designed to run career triage, document-generation standards and public job-source discovery workflows using data supplied by the user.
+Job Search Workflow Community Edition is a reusable, local-first framework for
+job triage, document-generation standards, application tracking, and public
+job-source discovery. It ships with fictitious fixtures and uses data supplied
+by each user; it does not require a hosted account.
 
 ## Quick Start
 
-1. After the independent public repository is released, clone it:
+1. Clone the Community Edition repository:
 
    ```bash
-   git clone https://github.com/<owner>/<repo>.git
-   cd <repo>
+   git clone https://github.com/rcnsnr/job-search-workflow.git
+   cd job-search-workflow
    ```
 
 2. Check the prerequisites first:
@@ -23,9 +27,14 @@ Job Search Workflow is intended to become a reusable framework that contains no 
    - Linux/macOS: `./scripts/setup.sh`
    - Windows CMD: `scripts\setup.bat`
 
-4. When sample fixtures are available, replace the copies under `user_data/` with your own verified information.
+4. Replace the generated sample files under `user_data/` with your own verified
+   information. Fictitious examples remain available under `fixtures/`.
 
 Read the [Setup and Verification Guide](docs/setup-and-verification.md) for the detailed behavior contract, support matrix and troubleshooting steps.
+
+Use the [Workflow Guards](docs/getting-started/WORKFLOW_GUARDS.md) to check
+duplicates, application field limits, lifecycle metadata, and configurable
+location or sponsorship eligibility without creating automatic actions.
 
 For source discovery, see the [Public Job Sources Quickstart](docs/sources/public-job-sources.md), the
 [Source Discovery Query Pack](docs/sources/source-discovery-query-pack.md), and
@@ -37,7 +46,7 @@ Required:
 
 - Git
 - Python 3.10+
-- Node.js 18+
+- Node.js 22.12+
 - npm
 
 Optional:
@@ -63,7 +72,8 @@ The setup scripts do not install missing system packages automatically and do no
 - `docs/sources/` - public-safe source discovery quickstart and example catalog
 - `docs/runbooks/` - repeatable operational procedures
 - `tools/browser-extension/` - `Job Search Workflow Capture` browser extension source
-- `fixtures/` - fictitious sample data to be added later
+- `fixtures/` - fictitious sample data for local demos and tests
+- `dashboard/` - local Community Operations Desk interface
 
 ## Browser Extension
 
@@ -81,11 +91,34 @@ Extension validation:
 
 ```bash
 cd tools/browser-extension
-npm install
+npm ci
 npm test
 npm run lint
 node scripts/validate-manifest.js
 ```
+
+## Community Operations Desk
+
+The local dashboard is the primary visual surface for Job Search Workflow
+Community Edition. It reads Markdown from `inbox/jobs/` and falls back to
+fictitious fixtures when no personal workspace exists.
+
+```bash
+pip install -e ".[dashboard]"
+python3 -m jsw dashboard
+```
+
+Open `http://localhost:3000` to use:
+
+- a local workspace overview and attention list
+- a responsive application pipeline
+- searchable job records with compact dates
+- profile and scoring reference views
+- a light-first interface with an optional dark theme
+
+The dashboard is read-only and does not require an account or external data
+transfer. `scripts/job_dashboard.py` is retained as a legacy compatibility
+entry point; `python3 -m jsw dashboard` is the canonical interface.
 
 ## Verification
 
@@ -105,7 +138,10 @@ The GitHub Actions workflow runs the Linux static and behavior checks and a real
 
 - Content under `user_data/`, `inbox/jobs/`, `runs/`, `outputs/` and `exports/` is excluded by `.gitignore`.
 - `.gitignore` alone does not guarantee prevention of personal-data leaks.
-- Before public release, run deterministic PII and secret scans, perform a manual content review, verify licensing and confirm that the Git history is clean.
+- Before every public contribution or release, run deterministic PII and secret
+  scans, perform a manual content review, verify licensing, and confirm that
+  Git history contains no unintended private data.
 - This framework does not guarantee employment, interviews or offers.
 
-See `.github/workflows/clone-scan.yml` for the CI definition.
+See `.github/workflows/ci.yml` for pull-request checks. Scheduled setup,
+career-page, and clone scans are intentionally separate operational workflows.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 > 1.0.0. Commercial use is not granted by this repository. See
 > [Commercial Use and SaaS Boundary](COMMERCIAL_USE.md).
 
+See the [Changelog](CHANGELOG.md) for the current unreleased change set.
+Report vulnerabilities through the private-first process in
+[Security Policy](SECURITY.md).
+
 Job Search Workflow Community Edition is a reusable, local-first framework for
 job triage, document-generation standards, application tracking, and public
 job-source discovery. It ships with fictitious fixtures and uses data supplied
@@ -35,6 +39,20 @@ by each user; it does not require a hosted account.
    information. Fictitious examples remain available under `fixtures/`.
 
 Read the [Setup and Verification Guide](docs/setup-and-verification.md) for the detailed behavior contract, support matrix and troubleshooting steps.
+
+## Documentation Map
+
+| Need | Guide |
+| --- | --- |
+| First end-to-end workflow | [Getting Started](docs/getting-started/GETTING_STARTED.md) |
+| Setup and supported environments | [Setup and Verification](docs/setup-and-verification.md) |
+| Read-only record checks | [Workflow Guards](docs/getting-started/WORKFLOW_GUARDS.md) |
+| Public job-source discovery | [Source Discovery Operations](docs/runbooks/source-discovery-operations.md) |
+| Browser extension install | [Extension Install](docs/runbooks/browser-extension-install.md) |
+| Local capture server | [Capture Server Setup](docs/runbooks/capture-server-setup.md) |
+| Vulnerability reporting | [Security Policy](SECURITY.md) |
+| License and SaaS boundary | [Commercial Use](COMMERCIAL_USE.md) |
+| Project changes | [Changelog](CHANGELOG.md) |
 
 Use the [Workflow Guards](docs/getting-started/WORKFLOW_GUARDS.md) to check
 duplicates, application field limits, lifecycle metadata, and configurable
@@ -131,12 +149,19 @@ From the public repository root on Linux or macOS:
 ```bash
 bash -n scripts/setup.sh
 shellcheck scripts/setup.sh
-python3 -m unittest discover -s tests -v
+python3 -m pip install -e ".[dashboard,dev]"
+python3 -m pytest -q
+PYTHONPATH=scripts python3 -m jsw smoke
+python3 scripts/scan_pii.py --path .
+python3 scripts/check_secret_hygiene.py
+python3 scripts/check_license_policy.py
 markdownlint-cli2 "**/*.md"
 ./scripts/setup.sh
 ```
 
-The GitHub Actions workflow runs the Linux static and behavior checks and a real Windows CMD smoke test as separate jobs. Windows support is not considered verified unless the Windows job passes.
+Pull-request CI runs Python, dashboard, privacy, documentation, and extension
+checks. The scheduled Setup Audit runs Linux and real Windows CMD setup jobs;
+Windows support is not considered verified unless that job passes.
 
 ## Security and Privacy
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > 1.0.0. Commercial use is not granted by this repository. See
 > [Commercial Use and SaaS Boundary](COMMERCIAL_USE.md).
 
-See the [Changelog](CHANGELOG.md) for the current unreleased change set.
+See the [Changelog](CHANGELOG.md) for the current release notes.
 Report vulnerabilities through the private-first process in
 [Security Policy](SECURITY.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Version
+
+The current `main` line is the only supported code line. The project has no
+stable release or long-term-support version yet.
+
+## Report a Vulnerability
+
+Do not publish exploit details, credentials, personal data, or private logs in
+a public issue.
+
+1. Use GitHub's **Security** tab and **Report a vulnerability** flow when it is
+   available for this repository.
+2. If private vulnerability reporting is unavailable, open a minimal issue
+   titled `Private security contact request` without technical details. The
+   maintainer will establish a private channel.
+
+Include affected files or versions, impact, reproduction conditions, and a
+minimal proof that contains no real personal data. Do not test against systems,
+accounts, or data you do not own or have permission to assess.
+
+## Scope Boundary
+
+Security reports cover Community Edition code and release artifacts. Questions
+about commercial licensing belong to the process in
+[Commercial Use and SaaS Boundary](COMMERCIAL_USE.md), not the vulnerability
+channel.
+
+No response-time or bounty commitment is currently offered.

--- a/config/eligibility.example.yaml
+++ b/config/eligibility.example.yaml
@@ -1,0 +1,8 @@
+# Copy this file outside Git-tracked paths and replace the sample regions with
+# the regions where you are eligible to work.
+eligible_regions:
+  - global
+  - europe
+
+allow_outside_regions_with_sponsorship: true
+relocation_allowed: false

--- a/config/lifecycle.yaml
+++ b/config/lifecycle.yaml
@@ -1,0 +1,19 @@
+states:
+  - captured
+  - triaged_reject
+  - triaged_conditional
+  - triaged_apply
+  - applied
+  - interview
+  - offer
+  - closed
+
+required_fields:
+  applied:
+    - applied_date
+  interview:
+    - applied_date
+  offer:
+    - applied_date
+  closed:
+    - closure_date

--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,0 +1,1 @@
+"""Local dashboard package for Job Search Workflow Community Edition."""

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -11,11 +11,14 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass, field
+from datetime import date, datetime
 from pathlib import Path
 from typing import Optional
 
+import bleach
 import markdown
 import yaml
 from fastapi import FastAPI, Request
@@ -27,16 +30,50 @@ from fastapi.templating import Jinja2Templates
 # Paths
 # ---------------------------------------------------------------------------
 
-ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = Path(__file__).resolve().parent
+SOURCE_ROOT = PACKAGE_ROOT.parent
+ROOT = Path(os.environ.get("JSW_WORKSPACE", Path.cwd())).expanduser().resolve()
+if not any((ROOT / marker).exists() for marker in ("config", "fixtures", "inbox", "user_data")):
+    if (SOURCE_ROOT / "fixtures").exists():
+        ROOT = SOURCE_ROOT
 JOBS_DIR = ROOT / "inbox" / "jobs"
 RUNS_DIR = ROOT / "runs"
 USER_DATA_DIR = ROOT / "user_data"
 CONFIG_DIR = ROOT / "config"
 FIXTURES_DIR = ROOT / "fixtures"
+PRODUCT_NAME = "Job Search Workflow Community Edition"
+MARKDOWN_CLEANER = bleach.Cleaner(
+    tags={
+        "a",
+        "blockquote",
+        "code",
+        "em",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "hr",
+        "li",
+        "ol",
+        "p",
+        "pre",
+        "strong",
+        "table",
+        "tbody",
+        "td",
+        "th",
+        "thead",
+        "tr",
+        "ul",
+    },
+    attributes={"a": ["href", "title"], "code": ["class"], "th": ["align"], "td": ["align"]},
+    protocols={"http", "https", "mailto"},
+    strip=True,
+    strip_comments=True,
+)
 
-# Fallback to fixtures if personal dirs don't exist (public/demo mode)
-DATA_DIR = JOBS_DIR if JOBS_DIR.exists() else FIXTURES_DIR
-PROFILE_PATH = USER_DATA_DIR / "career_profile.md" if USER_DATA_DIR.exists() else FIXTURES_DIR / "sample-profile.md"
 SCORING_CONFIG = CONFIG_DIR / "scoring.yaml" if CONFIG_DIR.exists() else ROOT / "config" / "scoring.yaml"
 
 # ---------------------------------------------------------------------------
@@ -70,6 +107,7 @@ class JobCard:
     quality_badge: str
     quality_recommendation: str
     compensation_signal: str
+    captured_at: str
     raw_content: str
 
 
@@ -102,11 +140,41 @@ def parse_frontmatter(text: str) -> tuple[dict, str]:
     return fm, text[match.end():]
 
 
+def render_safe_markdown(text: str) -> str:
+    """Render Markdown and remove executable or untrusted HTML content."""
+    rendered = markdown.markdown(text, extensions=["tables", "fenced_code"])
+    return MARKDOWN_CLEANER.clean(rendered)
+
+
+def format_compact_date(value: object) -> str:
+    """Render date-like values consistently without exposing raw timestamps."""
+    if isinstance(value, (datetime, date)):
+        return value.date().isoformat() if isinstance(value, datetime) else value.isoformat()
+    text = str(value or "").strip()
+    if not text:
+        return "Not provided"
+    iso_match = re.match(r"^(\d{4}-\d{2}-\d{2})", text)
+    return iso_match.group(1) if iso_match else text
+
+
 def infer_stage(fm: dict, body: str) -> str:
     """Infer pipeline stage from frontmatter and body content."""
+    triage_state = str(fm.get("triage_state", "")).lower()
     status = str(fm.get("application_status", "")).lower()
     decision = str(fm.get("initial_decision", "")).lower()
 
+    triage_stage_map = {
+        "captured": "new",
+        "triaged_reject": "reject",
+        "triaged_conditional": "shortlist",
+        "triaged_apply": "shortlist",
+        "applied": "applied",
+        "interview": "interview",
+        "offer": "offer",
+        "closed": "reject",
+    }
+    if triage_state in triage_stage_map:
+        return triage_stage_map[triage_state]
     if "reject" in status or "reject" in decision:
         return "reject"
     if "offer" in status:
@@ -163,17 +231,19 @@ def parse_compensation_signal(body: str) -> str:
     return "unknown"
 
 
-def load_job_cards() -> list[JobCard]:
-    """Load all job postings from data directory."""
+def load_job_cards_from(directory: Path) -> list[JobCard]:
+    """Load recognized job postings from one directory."""
     cards: list[JobCard] = []
-    if not DATA_DIR.exists():
+    if not directory.exists():
         return cards
 
-    for path in sorted(DATA_DIR.glob("*.md")):
+    for path in sorted(directory.glob("*.md")):
         if path.name in {"README.md", "source_consistency_report.md"}:
             continue
         text = path.read_text(encoding="utf-8")
         fm, body = parse_frontmatter(text)
+        if not fm or not (fm.get("role_title") and fm.get("company")):
+            continue
 
         title = str(fm.get("role_title", path.stem.replace("-", " ").title()))
         company = str(fm.get("company", "Unknown"))
@@ -186,6 +256,7 @@ def load_job_cards() -> list[JobCard]:
         decision = str(fm.get("initial_decision", ""))
         quality_badge, quality_rec = parse_quality_signals(body)
         comp_signal = parse_compensation_signal(body)
+        captured_at = format_compact_date(fm.get("captured_at"))
 
         cards.append(
             JobCard(
@@ -201,6 +272,7 @@ def load_job_cards() -> list[JobCard]:
                 quality_badge=quality_badge,
                 quality_recommendation=quality_rec,
                 compensation_signal=comp_signal,
+                captured_at=captured_at,
                 raw_content=text,
             )
         )
@@ -208,13 +280,20 @@ def load_job_cards() -> list[JobCard]:
     return cards
 
 
+def load_job_cards() -> list[JobCard]:
+    """Prefer real local records and fall back to public demo fixtures."""
+    local_cards = load_job_cards_from(JOBS_DIR)
+    return local_cards if local_cards else load_job_cards_from(FIXTURES_DIR)
+
+
 def load_profile_html() -> str:
     """Render career profile markdown to HTML."""
-    path = PROFILE_PATH
+    local_profile = USER_DATA_DIR / "career_profile.md"
+    path = local_profile if local_profile.is_file() else FIXTURES_DIR / "sample-profile.md"
     if not path.exists():
         return "<p>Profile not found.</p>"
     text = path.read_text(encoding="utf-8")
-    return markdown.markdown(text, extensions=["tables", "fenced_code"])
+    return render_safe_markdown(text)
 
 
 def load_scoring_config() -> dict:
@@ -230,11 +309,14 @@ def load_scoring_config() -> dict:
 
 def load_posting(filename: str) -> str:
     """Load a single job posting as rendered HTML."""
-    path = DATA_DIR / filename
-    if not path.exists() or not path.is_file():
+    if Path(filename).name != filename or not filename.endswith(".md"):
+        return "<p>Posting not found.</p>"
+    candidates = (JOBS_DIR / filename, FIXTURES_DIR / filename)
+    path = next((candidate for candidate in candidates if candidate.is_file()), None)
+    if path is None:
         return "<p>Posting not found.</p>"
     text = path.read_text(encoding="utf-8")
-    return markdown.markdown(text, extensions=["tables", "fenced_code"])
+    return render_safe_markdown(text)
 
 
 def compute_stage_counts(cards: list[JobCard]) -> dict[str, int]:
@@ -251,18 +333,38 @@ def compute_stage_counts(cards: list[JobCard]) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 app = FastAPI(
-    title="Job Search Workflow Dashboard",
+    title=PRODUCT_NAME,
     description="Local-first dashboard for job search pipeline tracking.",
     version="0.1.0",
 )
 
-templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+templates = Jinja2Templates(directory=str(PACKAGE_ROOT / "templates"))
+templates.env.globals["product_name"] = PRODUCT_NAME
 app.mount("/static", StaticFiles(directory=str(Path(__file__).parent / "static")), name="static")
 
 
 @app.get("/", response_class=HTMLResponse)
-async def kanban_board(request: Request):
-    """Kanban board view — main dashboard page."""
+async def overview(request: Request):
+    """Local workspace overview."""
+    cards = load_job_cards()
+    stage_counts = compute_stage_counts(cards)
+    attention_cards = [card for card in cards if card.stage in {"new", "triage", "shortlist"}][:5]
+    return templates.TemplateResponse(
+        request=request,
+        name="overview.html",
+        context={
+            "request": request,
+            "cards": cards,
+            "attention_cards": attention_cards,
+            "stage_counts": stage_counts,
+            "total_cards": len(cards),
+        },
+    )
+
+
+@app.get("/pipeline", response_class=HTMLResponse)
+async def pipeline_view(request: Request):
+    """Adaptive pipeline board."""
     cards = load_job_cards()
     stage_counts = compute_stage_counts(cards)
     cards_by_stage = {stage: [] for stage in PIPELINE_STAGES}
@@ -271,8 +373,9 @@ async def kanban_board(request: Request):
             cards_by_stage[card.stage].append(card)
 
     return templates.TemplateResponse(
-        "kanban.html",
-        {
+        request=request,
+        name="kanban.html",
+        context={
             "request": request,
             "stages": PIPELINE_STAGES,
             "cards_by_stage": cards_by_stage,
@@ -282,13 +385,29 @@ async def kanban_board(request: Request):
     )
 
 
+@app.get("/jobs", response_class=HTMLResponse)
+async def jobs_view(request: Request):
+    """Searchable local job inventory."""
+    cards = load_job_cards()
+    return templates.TemplateResponse(
+        request=request,
+        name="jobs.html",
+        context={
+            "request": request,
+            "cards": cards,
+            "stages": PIPELINE_STAGES,
+        },
+    )
+
+
 @app.get("/profile", response_class=HTMLResponse)
 async def profile_view(request: Request):
     """Profile summary view."""
     profile_html = load_profile_html()
     return templates.TemplateResponse(
-        "profile.html",
-        {
+        request=request,
+        name="profile.html",
+        context={
             "request": request,
             "profile_html": profile_html,
         },
@@ -300,8 +419,9 @@ async def posting_view(request: Request, filename: str):
     """Single job posting viewer."""
     posting_html = load_posting(filename)
     return templates.TemplateResponse(
-        "posting.html",
-        {
+        request=request,
+        name="posting.html",
+        context={
             "request": request,
             "filename": filename,
             "posting_html": posting_html,
@@ -315,8 +435,9 @@ async def scoring_view(request: Request):
     cards = load_job_cards()
     scoring_config = load_scoring_config()
     return templates.TemplateResponse(
-        "scoring.html",
-        {
+        request=request,
+        name="scoring.html",
+        context={
             "request": request,
             "cards": cards,
             "scoring_config": scoring_config,
@@ -342,6 +463,7 @@ async def api_cards():
             "quality_badge": c.quality_badge,
             "quality_recommendation": c.quality_recommendation,
             "compensation_signal": c.compensation_signal,
+            "captured_at": c.captured_at,
         }
         for c in cards
     ]

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -296,6 +296,20 @@ def load_profile_html() -> str:
     return render_safe_markdown(text)
 
 
+def load_target_roles_html() -> str:
+    """Render the owner's career direction and decision criteria."""
+    local_targets = USER_DATA_DIR / "target_roles.md"
+    path = local_targets if local_targets.is_file() else FIXTURES_DIR / "sample-target_roles.md"
+    if not path.exists():
+        return render_safe_markdown(
+            "## Decision criteria\n\n"
+            "Add target roles, preferred environments, must-haves, and boundaries "
+            "to `user_data/target_roles.md`."
+        )
+    text = path.read_text(encoding="utf-8")
+    return render_safe_markdown(text)
+
+
 def load_scoring_config() -> dict:
     """Load scoring.yaml configuration."""
     path = SCORING_CONFIG
@@ -404,12 +418,14 @@ async def jobs_view(request: Request):
 async def profile_view(request: Request):
     """Profile summary view."""
     profile_html = load_profile_html()
+    target_roles_html = load_target_roles_html()
     return templates.TemplateResponse(
         request=request,
         name="profile.html",
         context={
             "request": request,
             "profile_html": profile_html,
+            "target_roles_html": target_roles_html,
         },
     )
 
@@ -485,9 +501,11 @@ def smoke_test() -> bool:
     try:
         cards = load_job_cards()
         profile = load_profile_html()
+        target_roles = load_target_roles_html()
         config = load_scoring_config()
         print(f"  cards loaded: {len(cards)}")
         print(f"  profile length: {len(profile)} chars")
+        print(f"  target roles length: {len(target_roles)} chars")
         print(f"  scoring config keys: {list(config.keys())}")
         return True
     except Exception as e:

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -17,12 +17,13 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote
 
 import bleach
 import markdown
 import yaml
-from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -41,6 +42,7 @@ RUNS_DIR = ROOT / "runs"
 USER_DATA_DIR = ROOT / "user_data"
 CONFIG_DIR = ROOT / "config"
 FIXTURES_DIR = ROOT / "fixtures"
+APPLICATIONS_DIR = ROOT / "exports" / "applications"
 PRODUCT_NAME = "Job Search Workflow Community Edition"
 MARKDOWN_CLEANER = bleach.Cleaner(
     tags={
@@ -111,6 +113,18 @@ class JobCard:
     raw_content: str
 
 
+@dataclass(frozen=True)
+class ApplicationDocument:
+    """A read-only application document linked to one posting."""
+
+    filename: str
+    label: str
+    file_format: str
+    href: Optional[str]
+    action: str
+    path: Optional[Path]
+
+
 @dataclass
 class DashboardData:
     """Aggregated dashboard state."""
@@ -155,6 +169,20 @@ def format_compact_date(value: object) -> str:
         return "Not provided"
     iso_match = re.match(r"^(\d{4}-\d{2}-\d{2})", text)
     return iso_match.group(1) if iso_match else text
+
+
+def format_score_adjustment(value: object) -> str:
+    """Explain a numeric score adjustment without configuration jargon."""
+    try:
+        adjustment = float(value)
+    except (TypeError, ValueError):
+        return "Not configured"
+    if adjustment == 0:
+        return "No score change"
+    amount = abs(adjustment)
+    unit = "point" if amount == 1 else "points"
+    verb = "Subtract" if adjustment < 0 else "Add"
+    return f"{verb} {amount:.1f} {unit}"
 
 
 def infer_stage(fm: dict, body: str) -> str:
@@ -321,16 +349,120 @@ def load_scoring_config() -> dict:
         return {}
 
 
+def resolve_posting_path(filename: str) -> Optional[Path]:
+    """Resolve a posting without allowing path traversal."""
+    if Path(filename).name != filename or not filename.endswith(".md"):
+        return None
+    candidates = (JOBS_DIR / filename, FIXTURES_DIR / filename)
+    return next((candidate for candidate in candidates if candidate.is_file()), None)
+
+
 def load_posting(filename: str) -> str:
     """Load a single job posting as rendered HTML."""
-    if Path(filename).name != filename or not filename.endswith(".md"):
-        return "<p>Posting not found.</p>"
-    candidates = (JOBS_DIR / filename, FIXTURES_DIR / filename)
-    path = next((candidate for candidate in candidates if candidate.is_file()), None)
+    path = resolve_posting_path(filename)
     if path is None:
         return "<p>Posting not found.</p>"
     text = path.read_text(encoding="utf-8")
-    return render_safe_markdown(text)
+    _, body = parse_frontmatter(text)
+    return render_safe_markdown(body)
+
+
+def classify_application_document(path: Path) -> Optional[str]:
+    """Classify only files that are directly used in an application."""
+    normalized = re.sub(r"[_\s]+", "-", path.stem.lower())
+    suffix = path.suffix.lower()
+    if suffix not in {".docx", ".md", ".pdf", ".txt"}:
+        return None
+    if "cover-letter" in normalized:
+        return "Cover letter"
+    if "application-answer" in normalized:
+        return "Application answers"
+    if "cv" in normalized.split("-") or "resume" in normalized.split("-"):
+        return "CV"
+    return None
+
+
+def application_document_paths(posting_filename: str) -> list[Path]:
+    """Find application documents for one posting using a bounded convention."""
+    if Path(posting_filename).name != posting_filename or not posting_filename.endswith(".md"):
+        return []
+
+    package_dir = APPLICATIONS_DIR / Path(posting_filename).stem
+    try:
+        package_dir.resolve().relative_to(APPLICATIONS_DIR.resolve())
+    except ValueError:
+        return []
+    if package_dir.is_dir() and not package_dir.is_symlink():
+        return [
+            path
+            for path in package_dir.iterdir()
+            if path.is_file() and not path.is_symlink()
+        ]
+
+    if posting_filename == "sample-job-posting.md" and not (JOBS_DIR / posting_filename).is_file():
+        return [
+            FIXTURES_DIR / "sample-cover-letter.md",
+            FIXTURES_DIR / "sample-application-answers.md",
+        ]
+    return []
+
+
+def load_application_documents(posting_filename: str) -> list[ApplicationDocument]:
+    """Return existing, allowlisted application documents for one posting."""
+    order = {"CV": 0, "Cover letter": 1, "Application answers": 2}
+    documents: list[ApplicationDocument] = []
+    if (
+        posting_filename == "sample-job-posting.md"
+        and not (JOBS_DIR / posting_filename).is_file()
+    ):
+        documents.append(
+            ApplicationDocument(
+                filename="sample-cv.pdf",
+                label="CV",
+                file_format="PDF",
+                href=None,
+                action="Delivery format",
+                path=None,
+            )
+        )
+    for path in application_document_paths(posting_filename):
+        if not path.is_file():
+            continue
+        label = classify_application_document(path)
+        if label is None:
+            continue
+        encoded_posting = quote(posting_filename, safe="")
+        encoded_document = quote(path.name, safe="")
+        documents.append(
+            ApplicationDocument(
+                filename=path.name,
+                label=label,
+                file_format=path.suffix.removeprefix(".").upper(),
+                href=f"/application-file/{encoded_posting}/{encoded_document}",
+                action="Download" if path.suffix.lower() == ".docx" else "Open",
+                path=path,
+            )
+        )
+    return sorted(documents, key=lambda document: (order[document.label], document.filename))
+
+
+def resolve_application_document(
+    posting_filename: str, document_filename: str,
+) -> Optional[ApplicationDocument]:
+    """Resolve a requested document only from the posting's admitted set."""
+    if (
+        Path(document_filename).name != document_filename
+        or resolve_posting_path(posting_filename) is None
+    ):
+        return None
+    return next(
+        (
+            document
+            for document in load_application_documents(posting_filename)
+            if document.filename == document_filename and document.path is not None
+        ),
+        None,
+    )
 
 
 def compute_stage_counts(cards: list[JobCard]) -> dict[str, int]:
@@ -354,6 +486,7 @@ app = FastAPI(
 
 templates = Jinja2Templates(directory=str(PACKAGE_ROOT / "templates"))
 templates.env.globals["product_name"] = PRODUCT_NAME
+templates.env.filters["score_adjustment"] = format_score_adjustment
 app.mount("/static", StaticFiles(directory=str(Path(__file__).parent / "static")), name="static")
 
 
@@ -434,6 +567,7 @@ async def profile_view(request: Request):
 async def posting_view(request: Request, filename: str):
     """Single job posting viewer."""
     posting_html = load_posting(filename)
+    application_documents = load_application_documents(filename)
     return templates.TemplateResponse(
         request=request,
         name="posting.html",
@@ -441,6 +575,40 @@ async def posting_view(request: Request, filename: str):
             "request": request,
             "filename": filename,
             "posting_html": posting_html,
+            "application_documents": application_documents,
+        },
+    )
+
+
+@app.get("/application-file/{posting_filename}/{document_filename}")
+async def application_document_view(
+    request: Request, posting_filename: str, document_filename: str,
+):
+    """Open one allowlisted application document without mutating it."""
+    document = resolve_application_document(posting_filename, document_filename)
+    if document is None or document.path is None:
+        raise HTTPException(status_code=404, detail="Application document not found")
+
+    suffix = document.path.suffix.lower()
+    if suffix == ".pdf":
+        return FileResponse(document.path, media_type="application/pdf")
+    if suffix == ".docx":
+        return FileResponse(
+            document.path,
+            media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            filename=document.filename,
+        )
+
+    text = document.path.read_text(encoding="utf-8")
+    return templates.TemplateResponse(
+        request=request,
+        name="application_file.html",
+        context={
+            "request": request,
+            "posting_filename": posting_filename,
+            "document": document,
+            "document_html": render_safe_markdown(text) if suffix == ".md" else None,
+            "document_text": text if suffix != ".md" else None,
         },
     )
 

--- a/dashboard/static/app.js
+++ b/dashboard/static/app.js
@@ -1,0 +1,74 @@
+(() => {
+  "use strict";
+
+  const root = document.documentElement;
+  const themeToggle = document.querySelector(".theme-toggle");
+  const themeValue = document.querySelector(".theme-value");
+
+  const applyTheme = (theme) => {
+    const nextTheme = theme === "dark" ? "dark" : "light";
+    root.dataset.theme = nextTheme;
+    if (themeToggle) {
+      themeToggle.setAttribute("aria-pressed", String(nextTheme === "dark"));
+      themeToggle.setAttribute("aria-label", `Theme: ${nextTheme}. Activate to switch theme.`);
+    }
+    if (themeValue) {
+      themeValue.textContent = nextTheme === "dark" ? "Dark" : "Light";
+    }
+  };
+
+  applyTheme(root.dataset.theme);
+  themeToggle?.addEventListener("click", () => {
+    const nextTheme = root.dataset.theme === "dark" ? "light" : "dark";
+    applyTheme(nextTheme);
+    localStorage.setItem("jsw-theme", nextTheme);
+  });
+
+  const menuButton = document.querySelector(".mobile-menu-button");
+  const navigation = document.querySelector(".primary-nav");
+  menuButton?.addEventListener("click", () => {
+    const isOpen = navigation?.classList.toggle("open") ?? false;
+    menuButton.setAttribute("aria-expanded", String(isOpen));
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && navigation?.classList.contains("open")) {
+      navigation.classList.remove("open");
+      menuButton?.setAttribute("aria-expanded", "false");
+      menuButton?.focus();
+    }
+  });
+
+  const searchInput = document.querySelector("#job-search");
+  const stageSelect = document.querySelector("#job-stage");
+  const resetButton = document.querySelector("#job-filter-reset");
+  const jobRows = [...document.querySelectorAll(".job-row")];
+  const emptyFilter = document.querySelector("#jobs-empty-filter");
+
+  const filterJobs = () => {
+    const query = searchInput?.value.trim().toLocaleLowerCase() ?? "";
+    const stage = stageSelect?.value ?? "";
+    let visibleCount = 0;
+
+    jobRows.forEach((row) => {
+      const matchesQuery = !query || row.dataset.search?.toLocaleLowerCase().includes(query);
+      const matchesStage = !stage || row.dataset.stage === stage;
+      const visible = Boolean(matchesQuery && matchesStage);
+      row.hidden = !visible;
+      visibleCount += visible ? 1 : 0;
+    });
+
+    if (emptyFilter) {
+      emptyFilter.hidden = visibleCount > 0 || jobRows.length === 0;
+    }
+  };
+
+  searchInput?.addEventListener("input", filterJobs);
+  stageSelect?.addEventListener("change", filterJobs);
+  resetButton?.addEventListener("click", () => {
+    if (searchInput) searchInput.value = "";
+    if (stageSelect) stageSelect.value = "";
+    filterJobs();
+    searchInput?.focus();
+  });
+})();

--- a/dashboard/static/favicon.svg
+++ b/dashboard/static/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="JSW">
+  <rect width="64" height="64" rx="4" fill="#173330"/>
+  <path d="M13 15h38v34H13z" fill="none" stroke="#8de0d5" stroke-width="2"/>
+  <text x="32" y="37" fill="#f4f0e7" font-family="monospace" font-size="14" font-weight="700" text-anchor="middle">JSW</text>
+</svg>

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -1,220 +1,1486 @@
-/* Job Search Workflow Dashboard — Minimal CSS */
+/* Job Search Workflow Community Edition - Community Operations Desk */
 
 :root {
-  --bg: #0f172a;
-  --surface: #1e293b;
-  --surface-hover: #334155;
-  --text: #e2e8f0;
-  --text-muted: #94a3b8;
-  --accent: #3b82f6;
-  --accent-hover: #2563eb;
-  --border: #334155;
-  --green: #22c55e;
-  --yellow: #eab308;
-  --red: #ef4444;
-  --orange: #f97316;
-  --purple: #a855f7;
+  color-scheme: light;
+  --canvas: #f3f1ea;
+  --canvas-pattern: rgba(24, 66, 64, 0.035);
+  --surface: #fffdf8;
+  --surface-raised: #ffffff;
+  --surface-muted: #e9eee9;
+  --surface-strong: #d9e5df;
+  --ink: #172625;
+  --ink-soft: #425653;
+  --ink-muted: #586b67;
+  --line: #cbd6d0;
+  --line-strong: #9fb2aa;
+  --accent: #087f78;
+  --accent-strong: #055f5a;
+  --accent-soft: #d7efea;
+  --amber: #9a5b08;
+  --amber-soft: #fae8bf;
+  --red: #a43b34;
+  --red-soft: #f6ddd8;
+  --blue: #315f87;
+  --blue-soft: #dce8f3;
+  --sidebar: #173330;
+  --sidebar-surface: #21413d;
+  --sidebar-line: #395651;
+  --sidebar-ink: #f4f0e7;
+  --sidebar-muted: #b7c8c2;
+  --focus: #d58620;
+  --shadow: 0 18px 45px rgba(25, 48, 45, 0.09);
+  --radius-xs: 2px;
+  --radius-sm: 3px;
+  --radius-md: 5px;
+  --font-sans: "IBM Plex Sans", "Aptos", "Segoe UI Variable", sans-serif;
+  --font-mono: "IBM Plex Mono", "Cascadia Mono", "SFMono-Regular", monospace;
 }
 
-* { margin: 0; padding: 0; box-sizing: border-box; }
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --canvas: #15211f;
+  --canvas-pattern: rgba(206, 234, 225, 0.035);
+  --surface: #1c2b29;
+  --surface-raised: #223431;
+  --surface-muted: #293b38;
+  --surface-strong: #304b46;
+  --ink: #f2f0e8;
+  --ink-soft: #c7d3cf;
+  --ink-muted: #93aaa4;
+  --line: #38504b;
+  --line-strong: #58706a;
+  --accent: #67d3c7;
+  --accent-strong: #8ee2d8;
+  --accent-soft: #234b47;
+  --amber: #f2bd69;
+  --amber-soft: #513e25;
+  --red: #f29b91;
+  --red-soft: #54302e;
+  --blue: #9fc5e8;
+  --blue-soft: #2a4053;
+  --sidebar: #101917;
+  --sidebar-surface: #1b2927;
+  --sidebar-line: #31433f;
+  --sidebar-ink: #f5f1e8;
+  --sidebar-muted: #a8bbb5;
+  --focus: #f2bd69;
+  --shadow: 0 18px 45px rgba(0, 0, 0, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-width: 320px;
+  background: var(--canvas);
+}
 
 body {
-  font-family: system-ui, -apple-system, sans-serif;
-  background: var(--bg);
-  color: var(--text);
-  line-height: 1.6;
+  min-width: 320px;
+  min-height: 100vh;
+  margin: 0;
+  overflow-x: hidden;
+  background:
+    linear-gradient(90deg, var(--canvas-pattern) 1px, transparent 1px),
+    linear-gradient(var(--canvas-pattern) 1px, transparent 1px),
+    var(--canvas);
+  background-size: 28px 28px;
+  color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.55;
 }
 
-/* Nav */
-nav {
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-  padding: 0.75rem 1.5rem;
-  display: flex;
-  gap: 1.5rem;
-  align-items: center;
+button,
+input,
+select {
+  color: inherit;
+  font: inherit;
 }
 
-nav a {
-  color: var(--text-muted);
-  text-decoration: none;
-  font-size: 0.9rem;
-  font-weight: 500;
-  transition: color 0.15s;
+a {
+  color: inherit;
 }
 
-nav a:hover, nav a.active {
-  color: var(--text);
+button,
+a,
+input,
+select {
+  -webkit-tap-highlight-color: transparent;
 }
 
-nav .brand {
+:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 10px;
+  left: 10px;
+  padding: 10px 14px;
+  transform: translateY(-160%);
+  border-radius: var(--radius-xs);
+  background: var(--surface-raised);
+  color: var(--ink);
   font-weight: 700;
-  font-size: 1.1rem;
-  color: var(--text);
-  margin-right: auto;
+  box-shadow: var(--shadow);
 }
 
-/* Kanban */
-.kanban {
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 224px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  position: sticky;
+  z-index: 20;
+  top: 0;
   display: flex;
-  gap: 1rem;
-  padding: 1.5rem;
-  overflow-x: auto;
-  min-height: calc(100vh - 60px);
+  height: 100vh;
+  min-width: 0;
+  flex-direction: column;
+  padding: 24px 18px 18px;
+  overflow-y: auto;
+  border-right: 1px solid var(--sidebar-line);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.035), transparent 42%),
+    var(--sidebar);
+  color: var(--sidebar-ink);
 }
 
-.column {
-  flex: 1;
-  min-width: 250px;
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand-mark {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  flex: 0 0 42px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  border-radius: var(--radius-sm);
+  color: #8de0d5;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.brand-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.brand-copy strong {
+  font-size: 13px;
+  letter-spacing: -0.01em;
+}
+
+.brand-copy span {
+  margin-top: 4px;
+  color: var(--sidebar-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.mobile-menu-button {
+  display: none;
+}
+
+.primary-nav {
+  display: grid;
+  gap: 4px;
+  margin-top: 48px;
+}
+
+.primary-nav a {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  align-items: center;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--sidebar-muted);
+  font-size: 14px;
+  font-weight: 560;
+  text-decoration: none;
+  transition: 150ms ease;
+  transition-property: color, background, border-color;
+}
+
+.primary-nav a:hover {
+  border-color: var(--sidebar-line);
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--sidebar-ink);
+}
+
+.primary-nav a.active {
+  border-color: #4f6e67;
+  background: var(--sidebar-surface);
+  color: var(--sidebar-ink);
+}
+
+.nav-index {
+  color: #7ea19a;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+
+.primary-nav a.active .nav-index {
+  color: #7ce0d3;
+}
+
+.sidebar-footer {
+  display: grid;
+  gap: 12px;
+  margin-top: auto;
+  padding-top: 32px;
+}
+
+.local-status {
+  display: grid;
+  grid-template-columns: 9px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  padding: 12px;
+  border: 1px solid var(--sidebar-line);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  margin-top: 6px;
+  border-radius: 50%;
+  background: #79d3a7;
+  box-shadow: 0 0 0 3px rgba(121, 211, 167, 0.13);
+}
+
+.local-status span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.local-status strong {
+  font-size: 12px;
+}
+
+.local-status small {
+  margin-top: 2px;
+  color: var(--sidebar-muted);
+  font-size: 10px;
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--sidebar-line);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--sidebar-muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--sidebar-ink);
+}
+
+.theme-value {
+  color: #8de0d5;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.workspace {
+  min-width: 0;
+}
+
+.workspace-bar {
+  display: flex;
+  height: 45px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 32px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 86%, transparent);
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.workspace-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.workspace-state::before {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  content: "";
+}
+
+.main-content {
+  width: 100%;
+  min-width: 0;
+  max-width: 1580px;
+  margin: 0 auto;
+  padding: 38px 32px 64px;
+}
+
+.page-heading {
+  display: flex;
+  min-width: 0;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  margin-bottom: 28px;
+}
+
+.page-heading-featured {
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+  margin: 0 0 7px;
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.page-heading h1 {
+  max-width: 900px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(34px, 4vw, 58px);
+  font-weight: 650;
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+}
+
+.page-summary {
+  max-width: 680px;
+  margin: 14px 0 0;
+  color: var(--ink-soft);
+  font-size: 15px;
+}
+
+.heading-stat {
+  display: flex;
+  min-width: 104px;
+  flex-direction: column;
+  align-items: flex-end;
+  padding-left: 18px;
+  border-left: 2px solid var(--accent);
+}
+
+.heading-stat strong {
+  font-family: var(--font-mono);
+  font-size: 28px;
+  line-height: 1;
+}
+
+.heading-stat span {
+  margin-top: 5px;
+  color: var(--ink-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.edition-stamp {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  align-items: flex-end;
+  padding: 12px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  transform: rotate(-1deg);
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.edition-stamp strong {
+  color: var(--accent-strong);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.metric-card {
+  display: flex;
+  min-height: 138px;
+  min-width: 0;
+  flex-direction: column;
+  padding: 17px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
   background: var(--surface);
-  border-radius: 8px;
-  border: 1px solid var(--border);
+  box-shadow: 0 7px 20px rgba(25, 48, 45, 0.035);
+  animation: rise-in 380ms both;
+  animation-delay: calc(var(--index) * 45ms);
+}
+
+.metric-card > span {
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.metric-card strong {
+  margin-top: auto;
+  font-family: var(--font-mono);
+  font-size: 38px;
+  font-weight: 500;
+  letter-spacing: -0.05em;
+  line-height: 1;
+}
+
+.metric-card small {
+  margin-top: 8px;
+  color: var(--ink-muted);
+  font-size: 11px;
+}
+
+.metric-card-accent {
+  border-color: var(--accent);
+  background:
+    linear-gradient(135deg, transparent 58%, var(--accent-soft)),
+    var(--surface);
+}
+
+.overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(260px, 0.65fr);
+  gap: 18px;
+}
+
+.panel {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  box-shadow: 0 9px 24px rgba(25, 48, 45, 0.04);
+}
+
+.panel-header {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 19px 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 20px;
+  letter-spacing: -0.025em;
+}
+
+.text-link,
+.table-link {
+  color: var(--accent-strong);
+  font-weight: 650;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.text-link {
+  flex: 0 0 auto;
+  margin-top: 5px;
+  font-size: 12px;
+}
+
+.attention-list {
+  padding: 4px 20px 8px;
+}
+
+.attention-row {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr) 24px;
+  gap: 12px;
+  align-items: center;
+  min-width: 0;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--line);
+  text-decoration: none;
+}
+
+.attention-row:last-child {
+  border-bottom: 0;
+}
+
+.attention-row:hover .attention-copy strong {
+  color: var(--accent-strong);
+}
+
+.attention-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.attention-copy strong,
+.attention-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attention-copy strong {
+  font-size: 13px;
+}
+
+.attention-copy small {
+  margin-top: 3px;
+  color: var(--ink-muted);
+  font-size: 11px;
+}
+
+.row-arrow {
+  color: var(--accent);
+  font-size: 16px;
+}
+
+.stage-marker {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  align-items: center;
+  padding: 3px 7px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-xs);
+  background: var(--surface-muted);
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.stage-new,
+.stage-triage {
+  border-color: #9eb5c7;
+  background: var(--blue-soft);
+  color: var(--blue);
+}
+
+.stage-shortlist,
+.stage-interview {
+  border-color: #d9b879;
+  background: var(--amber-soft);
+  color: var(--amber);
+}
+
+.stage-applied,
+.stage-offer {
+  border-color: #8cbeb4;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.stage-reject {
+  border-color: #d9a49e;
+  background: var(--red-soft);
+  color: var(--red);
+}
+
+.stage-list {
+  margin: 0;
+  padding: 5px 20px 8px;
+  list-style: none;
+}
+
+.stage-list li {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.stage-list li:last-child {
+  border-bottom: 0;
+}
+
+.stage-order {
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
+.stage-list strong {
+  color: var(--ink);
+  font-family: var(--font-mono);
+}
+
+.principle-strip {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.45fr) minmax(0, 1fr);
+  gap: 28px;
+  align-items: center;
+  margin-top: 18px;
+  padding: 19px 20px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+}
+
+.principle-strip div {
   display: flex;
   flex-direction: column;
 }
 
-.column-header {
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--border);
+.principle-strip strong {
+  font-size: 17px;
+}
+
+.principle-strip p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.pipeline-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(235px, 100%), 1fr));
+  gap: 12px;
+  align-items: start;
+}
+
+.pipeline-column {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--surface) 78%, var(--canvas));
+  animation: rise-in 360ms both;
+  animation-delay: calc(var(--index) * 35ms);
+}
+
+.pipeline-column-header {
   display: flex;
+  align-items: center;
   justify-content: space-between;
+  gap: 14px;
+  padding: 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
+.stage-kicker {
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.pipeline-column-header h2 {
+  margin: 2px 0 0;
+  font-size: 14px;
+  letter-spacing: -0.015em;
+}
+
+.count-badge {
+  display: grid;
+  min-width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xs);
+  background: var(--surface-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.pipeline-cards {
+  display: grid;
+  gap: 7px;
+  padding: 8px;
+}
+
+.job-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xs);
+  background: var(--surface-raised);
+  color: inherit;
+  text-decoration: none;
+  transition: 150ms ease;
+  transition-property: border-color, transform, box-shadow;
+}
+
+.job-card:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(26, 57, 53, 0.08);
+}
+
+.job-card-company {
+  overflow: hidden;
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.job-card strong {
+  margin-top: 5px;
+  overflow-wrap: anywhere;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.job-card-location {
+  margin-top: 5px;
+  overflow-wrap: anywhere;
+  color: var(--ink-muted);
+  font-size: 11px;
+}
+
+.job-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 11px;
+  padding-top: 9px;
+  border-top: 1px solid var(--line);
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
+.score-chip,
+.muted-chip {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  padding: 2px 6px;
+  border-radius: var(--radius-xs);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.score-chip {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.muted-chip {
+  background: var(--surface-muted);
+  color: var(--ink-muted);
+}
+
+.empty-stage {
+  display: grid;
+  min-height: 76px;
+  place-items: center;
+  padding: 12px;
+  color: var(--ink-muted);
+  text-align: center;
+}
+
+.empty-stage span {
+  font-family: var(--font-mono);
+}
+
+.empty-stage p {
+  margin: 3px 0 0;
+  font-size: 10px;
+}
+
+.filter-bar {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(160px, 0.3fr) auto;
+  gap: 10px;
+  align-items: end;
+  margin-bottom: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+}
+
+.filter-field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.filter-field > span {
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.filter-field input,
+.filter-field select {
+  width: 100%;
+  height: 39px;
+  min-width: 0;
+  padding: 0 11px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-xs);
+  background: var(--surface-raised);
+}
+
+.filter-field input::placeholder {
+  color: var(--ink-muted);
+}
+
+.secondary-button {
+  min-height: 39px;
+  padding: 0 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-xs);
+  background: var(--surface-muted);
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.secondary-button:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.button-link {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.jobs-panel {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+}
+
+.jobs-list-header,
+.job-row {
+  display: grid;
+  grid-template-columns: minmax(230px, 1.7fr) minmax(150px, 1fr) 100px 94px 84px;
+  gap: 14px;
   align-items: center;
 }
 
-.column-header h3 {
-  font-size: 0.85rem;
+.jobs-list-header {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface-muted);
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-muted);
 }
 
-.column-count {
-  background: var(--surface-hover);
-  padding: 0.1rem 0.5rem;
-  border-radius: 12px;
-  font-size: 0.75rem;
-  color: var(--text-muted);
+.job-row {
+  min-width: 0;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink-soft);
+  font-size: 11px;
+  text-decoration: none;
 }
 
-.column-cards {
-  padding: 0.5rem;
-  flex: 1;
-  overflow-y: auto;
+.job-row:last-child {
+  border-bottom: 0;
 }
 
-/* Card */
-.card {
-  background: var(--surface-hover);
-  border-radius: 6px;
-  padding: 0.75rem;
-  margin-bottom: 0.5rem;
-  border: 1px solid var(--border);
-  cursor: pointer;
-  transition: border-color 0.15s;
+.job-row:hover {
+  background: color-mix(in srgb, var(--accent-soft) 42%, var(--surface));
 }
 
-.card:hover {
-  border-color: var(--accent);
+.job-row > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
-.card-title {
-  font-size: 0.9rem;
-  font-weight: 600;
-  margin-bottom: 0.25rem;
-}
-
-.card-company {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  margin-bottom: 0.5rem;
-}
-
-.card-meta {
+.job-primary {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
+  flex-direction: column;
 }
 
-.badge {
-  font-size: 0.7rem;
-  padding: 0.1rem 0.4rem;
-  border-radius: 4px;
-  font-weight: 500;
+.job-primary strong {
+  color: var(--ink);
+  font-size: 13px;
 }
 
-.badge-fit {
-  background: var(--accent);
-  color: white;
+.job-primary small {
+  margin-top: 2px;
+  color: var(--ink-muted);
+  font-size: 10px;
 }
 
-.badge-quality-clean { background: var(--green); color: white; }
-.badge-quality-caution { background: var(--yellow); color: var(--bg); }
-.badge-quality-flagged { background: var(--orange); color: white; }
-.badge-quality-reject { background: var(--red); color: white; }
-.badge-quality-skipped { background: var(--surface-hover); color: var(--text-muted); }
-
-.badge-compensation-transparent_aligned { background: var(--green); color: white; }
-.badge-compensation-transparent_low { background: var(--yellow); color: var(--bg); }
-.badge-compensation-opaque_expected_market { background: var(--orange); color: white; }
-.badge-compensation-opaque_normative_market { background: var(--surface-hover); color: var(--text-muted); }
-.badge-compensation-unknown { background: var(--surface-hover); color: var(--text-muted); }
-
-/* Profile / Posting */
-.content-page {
-  max-width: 800px;
-  margin: 2rem auto;
-  padding: 0 1.5rem;
+.date-value {
+  font-family: var(--font-mono);
+  font-size: 10px;
 }
 
-.content-page h1, .content-page h2, .content-page h3 {
-  margin-top: 1.5rem;
-  margin-bottom: 0.5rem;
+.empty-state {
+  padding: 28px 20px;
+  color: var(--ink-muted);
+  text-align: center;
 }
 
-.content-page table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 1rem 0;
+.empty-state strong {
+  color: var(--ink);
+  font-size: 13px;
 }
 
-.content-page th, .content-page td {
-  padding: 0.5rem;
-  border: 1px solid var(--border);
-  text-align: left;
+.empty-state p {
+  max-width: 480px;
+  margin: 6px auto 0;
+  font-size: 11px;
 }
 
-.content-page th {
-  background: var(--surface);
-}
-
-.content-page code {
-  background: var(--surface);
-  padding: 0.1rem 0.3rem;
-  border-radius: 3px;
+.empty-state code,
+.prose code {
+  padding: 2px 5px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xs);
+  background: var(--surface-muted);
+  font-family: var(--font-mono);
   font-size: 0.9em;
 }
 
-/* Scoring table */
-.scoring-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.scoring-table th, .scoring-table td {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--border);
-  text-align: left;
-  font-size: 0.85rem;
-}
-
-.scoring-table th {
-  background: var(--surface);
-  color: var(--text-muted);
+.read-only-badge,
+.panel-meta {
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.05em;
 }
 
-.scoring-table tr:hover {
+.read-only-badge {
+  padding: 7px 9px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-xs);
   background: var(--surface);
+}
+
+.document-layout {
+  display: grid;
+  grid-template-columns: 190px minmax(0, 820px);
+  gap: 18px;
+  align-items: start;
+}
+
+.document-note {
+  position: sticky;
+  top: 64px;
+  display: flex;
+  flex-direction: column;
+  padding: 15px;
+  border-top: 2px solid var(--accent);
+  background: var(--surface-muted);
+}
+
+.document-note strong {
+  font-size: 13px;
+}
+
+.document-note p {
+  margin: 7px 0 0;
+  color: var(--ink-muted);
+  font-size: 11px;
+}
+
+.document-panel {
+  padding: clamp(20px, 4vw, 42px);
+}
+
+.prose {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-soft);
+  font-size: 14px;
+}
+
+.prose > :first-child {
+  margin-top: 0;
+}
+
+.prose > :last-child {
+  margin-bottom: 0;
+}
+
+.prose h1,
+.prose h2,
+.prose h3 {
+  color: var(--ink);
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+}
+
+.prose h1 {
+  margin: 0 0 24px;
+  font-size: clamp(28px, 4vw, 42px);
+}
+
+.prose h2 {
+  margin: 34px 0 12px;
+  padding-top: 18px;
+  border-top: 1px solid var(--line);
+  font-size: 21px;
+}
+
+.prose h3 {
+  margin: 24px 0 10px;
+  font-size: 16px;
+}
+
+.prose p,
+.prose ul,
+.prose ol {
+  margin: 0 0 15px;
+}
+
+.prose li + li {
+  margin-top: 5px;
+}
+
+.prose a {
+  color: var(--accent-strong);
+  text-underline-offset: 3px;
+}
+
+.prose hr {
+  margin: 28px 0;
+  border: 0;
+  border-top: 1px solid var(--line);
+}
+
+.prose table {
+  width: 100%;
+  margin: 18px 0;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.prose th,
+.prose td {
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+}
+
+.prose th {
+  background: var(--surface-muted);
+  color: var(--ink);
+}
+
+.scoring-section + .scoring-section {
+  margin-top: 18px;
+}
+
+.table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  min-width: 640px;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.data-table th,
+.data-table td {
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.data-table tbody tr:last-child th,
+.data-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.data-table thead th {
+  background: var(--surface-muted);
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.data-table tbody th {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.data-table tbody tr:hover {
+  background: color-mix(in srgb, var(--accent-soft) 30%, var(--surface));
+}
+
+.breadcrumb {
+  display: flex;
+  gap: 7px;
+  margin-bottom: 22px;
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.breadcrumb a {
+  color: var(--accent-strong);
+  text-underline-offset: 3px;
+}
+
+.filename {
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.posting-document {
+  max-width: 940px;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@keyframes rise-in {
+  from {
+    opacity: 0;
+    transform: translateY(7px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 1100px) {
+  .app-shell {
+    grid-template-columns: 202px minmax(0, 1fr);
+  }
+
+  .sidebar {
+    padding-inline: 14px;
+  }
+
+  .main-content,
+  .workspace-bar {
+    padding-right: 24px;
+    padding-left: 24px;
+  }
+
+  .metrics-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .jobs-list-header,
+  .job-row {
+    grid-template-columns: minmax(210px, 1.5fr) minmax(135px, 1fr) 90px 92px;
+  }
+
+  .jobs-list-header > :last-child,
+  .job-row > :last-child {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    display: block;
+  }
+
+  .sidebar {
+    position: sticky;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    height: auto;
+    padding: 12px 16px;
+    overflow: visible;
+    border-right: 0;
+    border-bottom: 1px solid var(--sidebar-line);
+  }
+
+  .brand-mark {
+    width: 36px;
+    height: 36px;
+    flex-basis: 36px;
+  }
+
+  .mobile-menu-button {
+    display: flex;
+    min-width: 74px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 10px;
+    border: 1px solid var(--sidebar-line);
+    border-radius: var(--radius-xs);
+    background: transparent;
+    color: var(--sidebar-ink);
+    cursor: pointer;
+    font-size: 11px;
+  }
+
+  .primary-nav {
+    position: absolute;
+    top: calc(100% + 1px);
+    right: 0;
+    left: 0;
+    display: none;
+    grid-column: 1 / -1;
+    margin: 0;
+    padding: 8px 16px 14px;
+    border-bottom: 1px solid var(--sidebar-line);
+    background: var(--sidebar);
+    box-shadow: var(--shadow);
+  }
+
+  .primary-nav.open {
+    display: grid;
+  }
+
+  .sidebar-footer {
+    display: none;
+  }
+
+  .workspace-bar {
+    display: none;
+  }
+
+  .main-content {
+    padding-top: 28px;
+  }
+
+  .overview-grid,
+  .document-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .document-note {
+    position: static;
+  }
+}
+
+@media (max-width: 720px) {
+  .main-content {
+    padding: 24px 14px 48px;
+  }
+
+  .page-heading {
+    align-items: flex-start;
+    gap: 18px;
+  }
+
+  .page-heading h1 {
+    font-size: 38px;
+  }
+
+  .edition-stamp {
+    display: none;
+  }
+
+  .metrics-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric-card {
+    min-height: 118px;
+    padding: 14px;
+  }
+
+  .metric-card strong {
+    font-size: 31px;
+  }
+
+  .principle-strip {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .filter-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .jobs-list-header {
+    display: none;
+  }
+
+  .job-row {
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 16px;
+    padding: 15px;
+  }
+
+  .job-primary {
+    grid-column: 1 / -1;
+    padding-bottom: 9px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .job-row > span[data-label]::before {
+    display: block;
+    margin-bottom: 3px;
+    color: var(--ink-muted);
+    content: attr(data-label);
+    font-family: var(--font-mono);
+    font-size: 8px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .job-row > :last-child {
+    display: block;
+  }
+
+  .attention-row {
+    grid-template-columns: 70px minmax(0, 1fr);
+  }
+
+  .row-arrow {
+    display: none;
+  }
+}
+
+@media (max-width: 460px) {
+  .brand-copy strong {
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .page-heading {
+    flex-direction: column;
+  }
+
+  .heading-stat {
+    flex-direction: row;
+    align-items: baseline;
+    gap: 8px;
+    padding: 0;
+    border: 0;
+  }
+
+  .heading-stat strong {
+    font-size: 20px;
+  }
+
+  .metrics-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-card {
+    min-height: 105px;
+  }
+
+  .attention-list,
+  .stage-list {
+    padding-inline: 14px;
+  }
+
+  .panel-header {
+    padding-inline: 14px;
+  }
+
+  .attention-row {
+    grid-template-columns: 1fr;
+    gap: 7px;
+  }
+
+  .job-row {
+    grid-template-columns: 1fr;
+  }
+
+  .document-panel {
+    padding: 18px 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -319,6 +319,14 @@ select {
   text-transform: uppercase;
 }
 
+.copyright-notice {
+  display: grid;
+  gap: 2px;
+  color: var(--sidebar-muted);
+  font-size: 9px;
+  line-height: 1.5;
+}
+
 .workspace {
   min-width: 0;
 }

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -327,6 +327,15 @@ select {
   line-height: 1.5;
 }
 
+.copyright-notice a {
+  color: inherit;
+  text-underline-offset: 2px;
+}
+
+.copyright-notice a:hover {
+  color: var(--sidebar-ink);
+}
+
 .workspace {
   min-width: 0;
 }

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -1035,6 +1035,80 @@ select {
   background: var(--surface);
 }
 
+.profile-context {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.65fr) minmax(0, 1.35fr);
+  margin-bottom: 18px;
+  overflow: hidden;
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent-soft) 42%, var(--surface));
+}
+
+.profile-context-intro {
+  padding: clamp(20px, 3vw, 30px);
+  border-right: 1px solid var(--line);
+  background: var(--accent-soft);
+}
+
+.profile-context-intro h2 {
+  margin: 9px 0 8px;
+  font-size: clamp(23px, 3vw, 31px);
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+}
+
+.profile-context-intro p {
+  max-width: 34ch;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+
+.profile-context-content {
+  padding: clamp(20px, 3vw, 30px);
+}
+
+.profile-context-content h1,
+.profile-context-content h2,
+.profile-context-content h3 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.profile-context-content h1 {
+  margin-bottom: 24px;
+  font-size: clamp(24px, 3vw, 32px);
+}
+
+.profile-context-content h2 {
+  margin: 24px 0 12px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.profile-context-content h3 {
+  margin: 18px 0 8px;
+  font-size: 13px;
+}
+
+.profile-context-content p,
+.profile-context-content ul {
+  margin: 0;
+}
+
+.profile-context-content ul {
+  padding-left: 17px;
+}
+
+.profile-context-content li + li {
+  margin-top: 5px;
+}
+
 .document-layout {
   display: grid;
   grid-template-columns: 190px minmax(0, 820px);
@@ -1330,8 +1404,14 @@ select {
   }
 
   .overview-grid,
-  .document-layout {
+  .document-layout,
+  .profile-context {
     grid-template-columns: 1fr;
+  }
+
+  .profile-context-intro {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
   }
 
   .document-note {
@@ -1470,6 +1550,10 @@ select {
   }
 
   .document-panel {
+    padding: 18px 14px;
+  }
+
+  .profile-context-content {
     padding: 18px 14px;
   }
 }

--- a/dashboard/static/style.css
+++ b/dashboard/static/style.css
@@ -688,7 +688,7 @@ select {
 
 .principle-strip {
   display: grid;
-  grid-template-columns: minmax(220px, 0.45fr) minmax(0, 1fr);
+  grid-template-columns: minmax(190px, 0.4fr) minmax(220px, 0.75fr) minmax(190px, 0.55fr);
   gap: 28px;
   align-items: center;
   margin-top: 18px;
@@ -707,10 +707,32 @@ select {
   font-size: 17px;
 }
 
-.principle-strip p {
+.principle-strip > p {
   margin: 0;
   color: var(--ink-soft);
   font-size: 12px;
+}
+
+.community-support {
+  display: grid;
+  gap: 8px;
+  padding-left: 20px;
+  border-left: 1px solid var(--line-strong);
+}
+
+.community-support p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.community-support a {
+  width: fit-content;
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 700;
+  text-underline-offset: 3px;
 }
 
 .pipeline-grid {
@@ -1242,6 +1264,154 @@ select {
   margin-top: 18px;
 }
 
+.risk-score-guide {
+  padding: 20px;
+}
+
+.risk-score-explainer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 16px;
+  padding: 14px 15px;
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+}
+
+.risk-score-explainer strong {
+  color: var(--ink);
+  font-size: 13px;
+}
+
+.risk-score-explainer p {
+  margin: 4px 0 0;
+  color: var(--ink-soft);
+  font-size: 11px;
+}
+
+.score-example {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
+.score-example strong {
+  padding: 4px 6px;
+  background: var(--surface);
+  color: var(--accent-strong);
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.risk-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.risk-card {
+  min-width: 0;
+  border: 1px solid var(--line);
+  background: var(--surface-raised);
+}
+
+.risk-card header {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  gap: 10px;
+  min-height: 106px;
+  padding: 15px;
+  border-bottom: 1px solid var(--line);
+}
+
+.risk-card-index {
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+
+.risk-card h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 14px;
+  letter-spacing: -0.015em;
+}
+
+.risk-card header p {
+  margin: 6px 0 0;
+  color: var(--ink-muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.risk-card dl {
+  margin: 0;
+  padding: 5px 14px;
+}
+
+.risk-card dl div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.risk-card dl div:last-child {
+  border-bottom: 0;
+}
+
+.risk-card dt {
+  color: var(--ink-muted);
+  font-size: 10px;
+}
+
+.risk-card dd {
+  margin: 0;
+  color: var(--ink);
+  font-size: 10px;
+  font-weight: 650;
+  text-align: right;
+}
+
+.multi-risk-note {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 13px;
+  align-items: center;
+  margin-top: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--line-strong);
+  background: var(--amber-soft);
+}
+
+.multi-risk-note > span {
+  color: var(--amber);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.multi-risk-note strong {
+  color: var(--ink);
+  font-size: 12px;
+}
+
+.multi-risk-note p {
+  margin: 2px 0 0;
+  color: var(--ink-soft);
+  font-size: 10px;
+}
+
 .table-scroll {
   max-width: 100%;
   overflow-x: auto;
@@ -1304,8 +1474,154 @@ select {
   font-size: 11px;
 }
 
+.posting-layout {
+  display: grid;
+  gap: 18px;
+  align-items: start;
+  max-width: 1318px;
+}
+
 .posting-document {
+  width: 100%;
   max-width: 940px;
+}
+
+.application-files {
+  width: 100%;
+  max-width: 940px;
+  overflow: hidden;
+}
+
+.application-files-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--line);
+}
+
+.application-files-header h2 {
+  margin: 2px 0 0;
+  font-size: 20px;
+  letter-spacing: -0.025em;
+}
+
+.application-files-header > span {
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.application-file-list {
+  display: grid;
+}
+
+.application-file-row {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  min-width: 0;
+  padding: 15px 20px;
+  color: var(--ink-soft);
+  text-decoration: none;
+}
+
+.application-file-row + .application-file-row {
+  border-top: 1px solid var(--line);
+}
+
+.application-file-row:hover {
+  background: var(--surface-muted);
+}
+
+.application-file-row-static {
+  cursor: default;
+}
+
+.application-file-row-static:hover {
+  background: transparent;
+}
+
+.file-format {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  border: 1px solid var(--line-strong);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+}
+
+.application-file-copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.application-file-copy strong {
+  color: var(--ink);
+  font-size: 13px;
+}
+
+.application-file-copy small {
+  overflow: hidden;
+  color: var(--ink-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-action {
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.application-document {
+  max-width: 940px;
+}
+
+.plain-document {
+  max-width: 100%;
+  margin: 0;
+  overflow-x: auto;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+@media (min-width: 1320px) {
+  .posting-layout {
+    grid-template-columns: minmax(0, 940px) minmax(280px, 360px);
+  }
+
+  .application-files {
+    position: sticky;
+    top: 22px;
+  }
+
+  .application-files-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .application-file-row {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .file-action {
+    grid-column: 2;
+  }
 }
 
 [hidden] {
@@ -1472,6 +1788,32 @@ select {
     gap: 8px;
   }
 
+  .risk-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .risk-card header {
+    min-height: 0;
+  }
+
+  .risk-score-explainer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .score-example {
+    justify-content: flex-start;
+  }
+
+  .community-support {
+    margin-top: 6px;
+    padding-top: 12px;
+    padding-left: 0;
+    border-top: 1px solid var(--line-strong);
+    border-left: 0;
+  }
+
   .filter-bar {
     grid-template-columns: 1fr;
   }
@@ -1568,6 +1910,23 @@ select {
 
   .document-panel {
     padding: 18px 14px;
+  }
+
+  .risk-score-guide {
+    padding: 14px;
+  }
+
+  .application-files-header,
+  .application-file-row {
+    padding-inline: 14px;
+  }
+
+  .application-file-row {
+    grid-template-columns: 46px minmax(0, 1fr);
+  }
+
+  .file-action {
+    grid-column: 2;
   }
 
   .profile-context-content {

--- a/dashboard/templates/application_file.html
+++ b/dashboard/templates/application_file.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}{{ document.label }} · {{ product_name }}{% endblock %}
+{% block nav_jobs %}active{% endblock %}
+{% block content %}
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/jobs">Jobs</a>
+  <span aria-hidden="true">/</span>
+  <a href="/posting/{{ posting_filename }}">Job detail</a>
+  <span aria-hidden="true">/</span>
+  <span>{{ document.label }}</span>
+</nav>
+<section class="page-heading page-heading-detail">
+  <div>
+    <p class="eyebrow">Application file · {{ document.file_format }}</p>
+    <h1>{{ document.label }}</h1>
+    <p class="page-summary filename">{{ document.filename }}</p>
+  </div>
+  <a class="secondary-button button-link" href="/posting/{{ posting_filename }}">Back to job</a>
+</section>
+{% if document_html %}
+<article class="prose panel document-panel application-document">
+  {{ document_html | safe }}
+</article>
+{% else %}
+<article class="panel document-panel application-document">
+  <pre class="plain-document">{{ document_text }}</pre>
+</article>
+{% endif %}
+{% endblock %}

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -1,18 +1,81 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}Job Search Workflow{% endblock %}</title>
+  <meta name="color-scheme" content="light dark">
+  <title>{% block title %}{{ product_name }}{% endblock %}</title>
+  <script>
+    document.documentElement.dataset.theme = localStorage.getItem("jsw-theme") || "light";
+  </script>
+  <link rel="icon" href="/static/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <nav>
-    <span class="brand">Job Search Workflow</span>
-    <a href="/" class="{% block nav_kanban %}{% endblock %}">Pipeline</a>
-    <a href="/profile" class="{% block nav_profile %}{% endblock %}">Profile</a>
-    <a href="/scoring" class="{% block nav_scoring %}{% endblock %}">Scoring</a>
-  </nav>
-  {% block content %}{% endblock %}
+  <a class="skip-link" href="#main-content">Skip to content</a>
+  <div class="app-shell">
+    <aside class="sidebar">
+      <a class="brand" href="/" aria-label="Job Search Workflow Community Edition home">
+        <span class="brand-mark" aria-hidden="true">JSW</span>
+        <span class="brand-copy">
+          <strong>Job Search Workflow</strong>
+          <span>Community Edition</span>
+        </span>
+      </a>
+
+      <button class="mobile-menu-button" type="button" aria-expanded="false" aria-controls="primary-navigation">
+        <span>Menu</span>
+        <span aria-hidden="true">+</span>
+      </button>
+
+      <nav id="primary-navigation" class="primary-nav" aria-label="Primary navigation">
+        <a href="/" class="{% block nav_overview %}{% endblock %}">
+          <span class="nav-index" aria-hidden="true">01</span>
+          <span>Overview</span>
+        </a>
+        <a href="/pipeline" class="{% block nav_pipeline %}{% endblock %}">
+          <span class="nav-index" aria-hidden="true">02</span>
+          <span>Pipeline</span>
+        </a>
+        <a href="/jobs" class="{% block nav_jobs %}{% endblock %}">
+          <span class="nav-index" aria-hidden="true">03</span>
+          <span>Jobs</span>
+        </a>
+        <a href="/profile" class="{% block nav_profile %}{% endblock %}">
+          <span class="nav-index" aria-hidden="true">04</span>
+          <span>Profile</span>
+        </a>
+        <a href="/scoring" class="{% block nav_scoring %}{% endblock %}">
+          <span class="nav-index" aria-hidden="true">05</span>
+          <span>Scoring</span>
+        </a>
+      </nav>
+
+      <div class="sidebar-footer">
+        <div class="local-status">
+          <span class="status-dot" aria-hidden="true"></span>
+          <span>
+            <strong>Local-first</strong>
+            <small>Data stays on this device</small>
+          </span>
+        </div>
+        <button class="theme-toggle" type="button" aria-pressed="false">
+          <span>Theme</span>
+          <span class="theme-value">Light</span>
+        </button>
+      </div>
+    </aside>
+
+    <div class="workspace">
+      <header class="workspace-bar">
+        <span>Community Operations Desk</span>
+        <span class="workspace-state">Read-only view</span>
+      </header>
+      <main id="main-content" class="main-content" tabindex="-1">
+        {% block content %}{% endblock %}
+      </main>
+    </div>
+  </div>
+  <script src="/static/app.js" defer></script>
 </body>
 </html>

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -63,6 +63,10 @@
           <span>Theme</span>
           <span class="theme-value">Light</span>
         </button>
+        <small class="copyright-notice">
+          <span>Copyright &copy; 2026 Orcun Sener</span>
+          <span>Community Edition - Noncommercial use only</span>
+        </small>
       </div>
     </aside>
 

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -64,7 +64,10 @@
           <span class="theme-value">Light</span>
         </button>
         <small class="copyright-notice">
-          <span>Copyright &copy; 2026 Orcun Sener</span>
+          <span>
+            Copyright &copy; 2026
+            <a href="https://github.com/rcnsnr/job-search-workflow" target="_blank" rel="noopener noreferrer">Orcun Sener</a>
+          </span>
           <span>Community Edition - Noncommercial use only</span>
         </small>
       </div>

--- a/dashboard/templates/jobs.html
+++ b/dashboard/templates/jobs.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% block title %}Jobs · {{ product_name }}{% endblock %}
+{% block nav_jobs %}active{% endblock %}
+{% block content %}
+<section class="page-heading">
+  <div>
+    <p class="eyebrow">Local inventory</p>
+    <h1>Jobs</h1>
+    <p class="page-summary">Search and review normalized job records without changing the source files.</p>
+  </div>
+  <div class="heading-stat">
+    <strong>{{ cards | length }}</strong>
+    <span>Records</span>
+  </div>
+</section>
+
+<section class="filter-bar" aria-label="Job filters">
+  <label class="filter-field filter-field-search" for="job-search">
+    <span>Search</span>
+    <input id="job-search" type="search" placeholder="Company, role, or location" autocomplete="off">
+  </label>
+  <label class="filter-field" for="job-stage">
+    <span>Stage</span>
+    <select id="job-stage">
+      <option value="">All stages</option>
+      {% for stage in stages %}
+      <option value="{{ stage }}">{{ stage | replace('_', ' ') | title }}</option>
+      {% endfor %}
+    </select>
+  </label>
+  <button id="job-filter-reset" class="secondary-button" type="button">Reset</button>
+</section>
+
+<section class="jobs-panel" aria-labelledby="jobs-list-title">
+  <header class="jobs-list-header" aria-hidden="true">
+    <span>Role</span>
+    <span>Location</span>
+    <span>Stage</span>
+    <span>Captured</span>
+    <span>Score</span>
+  </header>
+  <div id="jobs-list" class="jobs-list">
+    {% for card in cards %}
+    <a class="job-row" href="/posting/{{ card.filename }}" data-stage="{{ card.stage }}" data-search="{{ card.company }} {{ card.title }} {{ card.location }}">
+      <span class="job-primary">
+        <strong>{{ card.title }}</strong>
+        <small>{{ card.company }}</small>
+      </span>
+      <span data-label="Location">{{ card.location or 'Not provided' }}</span>
+      <span data-label="Stage"><span class="stage-marker stage-{{ card.stage }}">{{ card.stage | title }}</span></span>
+      <span data-label="Captured" class="date-value">{{ card.captured_at }}</span>
+      <span data-label="Score">
+        {% if card.fit_score is not none %}
+        <strong>{{ card.fit_score }}/5</strong>
+        {% else %}
+        <span class="muted-chip">Needs review</span>
+        {% endif %}
+      </span>
+    </a>
+    {% else %}
+    <div class="empty-state">
+      <strong>No job records found</strong>
+      <p>Add Markdown records under <code>inbox/jobs/</code> and refresh the page.</p>
+    </div>
+    {% endfor %}
+  </div>
+  <div id="jobs-empty-filter" class="empty-state" hidden>
+    <strong>No matching jobs</strong>
+    <p>Change the search text or reset the stage filter.</p>
+  </div>
+</section>
+{% endblock %}

--- a/dashboard/templates/kanban.html
+++ b/dashboard/templates/kanban.html
@@ -1,36 +1,52 @@
 {% extends "base.html" %}
-{% block title %}Pipeline — Job Search Workflow{% endblock %}
-{% block nav_kanban %}active{% endblock %}
+{% block title %}Pipeline · {{ product_name }}{% endblock %}
+{% block nav_pipeline %}active{% endblock %}
 {% block content %}
-<div class="kanban">
+<section class="page-heading">
+  <div>
+    <p class="eyebrow">Application flow</p>
+    <h1>Pipeline</h1>
+    <p class="page-summary">A compact stage-by-stage view of the local job search workflow.</p>
+  </div>
+  <div class="heading-stat">
+    <strong>{{ total_cards }}</strong>
+    <span>Total jobs</span>
+  </div>
+</section>
+
+<section class="pipeline-grid" aria-label="Job pipeline">
   {% for stage in stages %}
-  <div class="column">
-    <div class="column-header">
-      <h3>{{ stage | capitalize }}</h3>
-      <span class="column-count">{{ stage_counts[stage] }}</span>
-    </div>
-    <div class="column-cards">
+  <article class="pipeline-column" data-stage="{{ stage }}" style="--index: {{ loop.index }}">
+    <header class="pipeline-column-header">
+      <div>
+        <span class="stage-kicker">Stage {{ "%02d" | format(loop.index) }}</span>
+        <h2>{{ stage | replace('_', ' ') | title }}</h2>
+      </div>
+      <span class="count-badge">{{ stage_counts[stage] }}</span>
+    </header>
+    <div class="pipeline-cards">
       {% for card in cards_by_stage[stage] %}
-      <a href="/posting/{{ card.filename }}" style="text-decoration:none;color:inherit;">
-        <div class="card">
-          <div class="card-title">{{ card.title }}</div>
-          <div class="card-company">{{ card.company }} · {{ card.location }}</div>
-          <div class="card-meta">
-            {% if card.fit_score is not none %}
-            <span class="badge badge-fit">{{ card.fit_score }}/5</span>
-            {% endif %}
-            {% if card.quality_badge and card.quality_badge != 'skipped' %}
-            <span class="badge badge-{{ card.quality_badge | replace('_', '-') }}">{{ card.quality_badge | replace('quality_', '') }}</span>
-            {% endif %}
-            {% if card.compensation_signal and card.compensation_signal != 'unknown' %}
-            <span class="badge badge-compensation-{{ card.compensation_signal | replace('_', '-') }}">{{ card.compensation_signal | replace('_', ' ') }}</span>
-            {% endif %}
-          </div>
-        </div>
+      <a class="job-card" href="/posting/{{ card.filename }}">
+        <span class="job-card-company">{{ card.company }}</span>
+        <strong>{{ card.title }}</strong>
+        <span class="job-card-location">{{ card.location }}</span>
+        <span class="job-card-footer">
+          <span>{{ card.captured_at }}</span>
+          {% if card.fit_score is not none %}
+          <span class="score-chip">{{ card.fit_score }}/5</span>
+          {% else %}
+          <span class="muted-chip">Needs review</span>
+          {% endif %}
+        </span>
       </a>
+      {% else %}
+      <div class="empty-stage">
+        <span aria-hidden="true">—</span>
+        <p>No jobs in this stage.</p>
+      </div>
       {% endfor %}
     </div>
-  </div>
+  </article>
   {% endfor %}
-</div>
+</section>
 {% endblock %}

--- a/dashboard/templates/overview.html
+++ b/dashboard/templates/overview.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+{% block title %}Overview · {{ product_name }}{% endblock %}
+{% block nav_overview %}active{% endblock %}
+{% block content %}
+<section class="page-heading page-heading-featured">
+  <div>
+    <p class="eyebrow">Local decision workspace</p>
+    <h1>Workspace overview</h1>
+    <p class="page-summary">See what is moving, what needs review, and where your attention is useful next.</p>
+  </div>
+  <div class="edition-stamp" aria-label="Community Edition">
+    <span>Community</span>
+    <strong>Edition</strong>
+  </div>
+</section>
+
+<section class="metrics-grid" aria-label="Workspace totals">
+  <article class="metric-card" style="--index: 1">
+    <span>Local files</span>
+    <strong>{{ total_cards }}</strong>
+    <small>Recognized job records</small>
+  </article>
+  <article class="metric-card" style="--index: 2">
+    <span>Shortlisted</span>
+    <strong>{{ stage_counts['shortlist'] }}</strong>
+    <small>Worth a closer look</small>
+  </article>
+  <article class="metric-card" style="--index: 3">
+    <span>Applied</span>
+    <strong>{{ stage_counts['applied'] }}</strong>
+    <small>Applications in motion</small>
+  </article>
+  <article class="metric-card metric-card-accent" style="--index: 4">
+    <span>Interviews</span>
+    <strong>{{ stage_counts['interview'] }}</strong>
+    <small>Active conversations</small>
+  </article>
+</section>
+
+<div class="overview-grid">
+  <section class="panel" aria-labelledby="attention-title">
+    <header class="panel-header">
+      <div>
+        <p class="eyebrow">Review queue</p>
+        <h2 id="attention-title">Needs attention</h2>
+      </div>
+      <a class="text-link" href="/jobs">View all jobs</a>
+    </header>
+    <div class="attention-list">
+      {% for card in attention_cards %}
+      <a class="attention-row" href="/posting/{{ card.filename }}">
+        <span class="stage-marker stage-{{ card.stage }}">{{ card.stage | title }}</span>
+        <span class="attention-copy">
+          <strong>{{ card.title }}</strong>
+          <small>{{ card.company }} · {{ card.location }}</small>
+        </span>
+        <span class="row-arrow" aria-hidden="true">↗</span>
+      </a>
+      {% else %}
+      <div class="empty-state">
+        <strong>No immediate review items</strong>
+        <p>Add job Markdown files under <code>inbox/jobs/</code> to populate this workspace.</p>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="panel" aria-labelledby="snapshot-title">
+    <header class="panel-header">
+      <div>
+        <p class="eyebrow">Current shape</p>
+        <h2 id="snapshot-title">Pipeline snapshot</h2>
+      </div>
+      <a class="text-link" href="/pipeline">Open pipeline</a>
+    </header>
+    <ol class="stage-list">
+      {% for stage, count in stage_counts.items() %}
+      <li>
+        <span class="stage-order">{{ "%02d" | format(loop.index) }}</span>
+        <span>{{ stage | replace('_', ' ') | title }}</span>
+        <strong>{{ count }}</strong>
+      </li>
+      {% endfor %}
+    </ol>
+  </section>
+</div>
+
+<section class="principle-strip" aria-label="Community Edition principles">
+  <div>
+    <span class="eyebrow">Community Edition</span>
+    <strong>Your workflow, your files.</strong>
+  </div>
+  <p>The dashboard reads local Markdown and does not require an account, hosted service, or external data transfer.</p>
+</section>
+{% endblock %}

--- a/dashboard/templates/overview.html
+++ b/dashboard/templates/overview.html
@@ -91,5 +91,9 @@
     <strong>Your workflow, your files.</strong>
   </div>
   <p>The dashboard reads local Markdown and does not require an account, hosted service, or external data transfer.</p>
+  <div class="community-support">
+    <p>Found this useful? Your support helps keep the Community Edition improving.</p>
+    <a href="https://github.com/sponsors/rcnsnr" target="_blank" rel="noopener noreferrer">Sponsor this project <span aria-hidden="true">↗</span></a>
+  </div>
 </section>
 {% endblock %}

--- a/dashboard/templates/posting.html
+++ b/dashboard/templates/posting.html
@@ -15,7 +15,43 @@
   </div>
   <a class="secondary-button button-link" href="/pipeline">View pipeline</a>
 </section>
-<article class="prose panel document-panel posting-document">
-  {{ posting_html | safe }}
-</article>
+<div class="posting-layout">
+  <article class="prose panel document-panel posting-document">
+    {{ posting_html | safe }}
+  </article>
+  {% if application_documents %}
+  <section class="application-files panel" aria-labelledby="application-files-title">
+    <header class="application-files-header">
+      <div>
+        <p class="eyebrow">Ready to use</p>
+        <h2 id="application-files-title">Application files</h2>
+      </div>
+      <span>{{ application_documents | length }} available</span>
+    </header>
+    <div class="application-file-list">
+      {% for document in application_documents %}
+      {% if document.href %}
+      <a class="application-file-row" href="{{ document.href }}">
+        <span class="file-format">{{ document.file_format }}</span>
+        <span class="application-file-copy">
+          <strong>{{ document.label }}</strong>
+          <small>{{ document.filename }}</small>
+        </span>
+        <span class="file-action">{{ document.action }} <span aria-hidden="true">↗</span></span>
+      </a>
+      {% else %}
+      <div class="application-file-row application-file-row-static">
+        <span class="file-format">{{ document.file_format }}</span>
+        <span class="application-file-copy">
+          <strong>{{ document.label }}</strong>
+          <small>{{ document.filename }}</small>
+        </span>
+        <span class="file-action">{{ document.action }}</span>
+      </div>
+      {% endif %}
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+</div>
 {% endblock %}

--- a/dashboard/templates/posting.html
+++ b/dashboard/templates/posting.html
@@ -1,10 +1,21 @@
 {% extends "base.html" %}
-{% block title %}{{ filename }} — Job Search Workflow{% endblock %}
-{% block nav_kanban %}active{% endblock %}
+{% block title %}Job detail · {{ product_name }}{% endblock %}
+{% block nav_jobs %}active{% endblock %}
 {% block content %}
-<div class="content-page">
-  <p><a href="/" style="color:var(--text-muted);text-decoration:none;">← Back to pipeline</a></p>
-  <hr style="border:none;border-top:1px solid var(--border);margin:1rem 0;">
+<nav class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/jobs">Jobs</a>
+  <span aria-hidden="true">/</span>
+  <span>Job detail</span>
+</nav>
+<section class="page-heading page-heading-detail">
+  <div>
+    <p class="eyebrow">Source record</p>
+    <h1>Job detail</h1>
+    <p class="page-summary filename">{{ filename }}</p>
+  </div>
+  <a class="secondary-button button-link" href="/pipeline">View pipeline</a>
+</section>
+<article class="prose panel document-panel posting-document">
   {{ posting_html | safe }}
-</div>
+</article>
 {% endblock %}

--- a/dashboard/templates/profile.html
+++ b/dashboard/templates/profile.html
@@ -1,8 +1,23 @@
 {% extends "base.html" %}
-{% block title %}Profile — Job Search Workflow{% endblock %}
+{% block title %}Profile · {{ product_name }}{% endblock %}
 {% block nav_profile %}active{% endblock %}
 {% block content %}
-<div class="content-page">
-  {{ profile_html | safe }}
-</div>
+<section class="page-heading">
+  <div>
+    <p class="eyebrow">Local context</p>
+    <h1>Profile</h1>
+    <p class="page-summary">The profile content used by your local workflow and scoring decisions.</p>
+  </div>
+  <span class="read-only-badge">Read only</span>
+</section>
+<section class="document-layout">
+  <aside class="document-note">
+    <span class="eyebrow">Source of truth</span>
+    <strong>Local Markdown</strong>
+    <p>Edit your profile file directly. This view never rewrites it.</p>
+  </aside>
+  <article class="prose panel document-panel">
+    {{ profile_html | safe }}
+  </article>
+</section>
 {% endblock %}

--- a/dashboard/templates/profile.html
+++ b/dashboard/templates/profile.html
@@ -6,9 +6,19 @@
   <div>
     <p class="eyebrow">Local context</p>
     <h1>Profile</h1>
-    <p class="page-summary">The profile content used by your local workflow and scoring decisions.</p>
+    <p class="page-summary">See the evidence, direction, and boundaries that guide your local decisions.</p>
   </div>
   <span class="read-only-badge">Read only</span>
+</section>
+<section class="profile-context panel" aria-labelledby="career-direction-title">
+  <header class="profile-context-intro">
+    <span class="eyebrow">At a glance</span>
+    <h2 id="career-direction-title">Decision compass</h2>
+    <p>Keep the roles you want and the trade-offs you will accept visible while reviewing opportunities.</p>
+  </header>
+  <div class="prose profile-context-content">
+    {{ target_roles_html | safe }}
+  </div>
 </section>
 <section class="document-layout">
   <aside class="document-note">

--- a/dashboard/templates/scoring.html
+++ b/dashboard/templates/scoring.html
@@ -15,45 +15,79 @@
   <header class="panel-header">
     <div>
       <p class="eyebrow">Risk adjustments</p>
-      <h2>Quality audit penalties</h2>
+      <h2>How quality risks change a score</h2>
     </div>
   </header>
   {% if quality_audit %}
-  <div class="table-scroll" tabindex="0" aria-label="Quality audit penalties table">
-    <table class="data-table">
-      <thead>
-        <tr>
-          <th scope="col">Category</th>
-          <th scope="col">Low</th>
-          <th scope="col">Medium</th>
-          <th scope="col">High</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th scope="row">Ghost Job</th>
-          <td>{{ quality_audit.get('ghost_job_penalty', {}).get('low', '—') }}</td>
-          <td>{{ quality_audit.get('ghost_job_penalty', {}).get('medium', '—') }}</td>
-          <td>{{ quality_audit.get('ghost_job_penalty', {}).get('high', '—') }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Exploitation</th>
-          <td>{{ quality_audit.get('exploitation_penalty', {}).get('low', '—') }}</td>
-          <td>{{ quality_audit.get('exploitation_penalty', {}).get('medium', '—') }}</td>
-          <td>{{ quality_audit.get('exploitation_penalty', {}).get('high', '—') }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Chaos</th>
-          <td>{{ quality_audit.get('chaos_penalty', {}).get('low', '—') }}</td>
-          <td>{{ quality_audit.get('chaos_penalty', {}).get('medium', '—') }}</td>
-          <td>{{ quality_audit.get('chaos_penalty', {}).get('high', '—') }}</td>
-        </tr>
-        <tr>
-          <th scope="row">Multi-high escalation</th>
-          <td colspan="3">{{ quality_audit.get('multi_high_escalation', '—') }}</td>
-        </tr>
-      </tbody>
-    </table>
+  <div class="risk-score-guide">
+    <div class="risk-score-explainer">
+      <div>
+        <strong>How to read this</strong>
+        <p>Risk deductions are applied after the role receives its 0-5 fit score.</p>
+      </div>
+      <div class="score-example" aria-label="Example adjusted score">
+        <span>4.2 fit score</span>
+        <span aria-hidden="true">−</span>
+        <span>0.5 risk</span>
+        <span aria-hidden="true">=</span>
+        <strong>3.7 adjusted</strong>
+      </div>
+    </div>
+
+    <div class="risk-card-grid">
+      <article class="risk-card">
+        <header>
+          <span class="risk-card-index">01</span>
+          <div>
+            <h3>Inactive posting risk</h3>
+            <p>Signals that the company may not be actively filling the role.</p>
+          </div>
+        </header>
+        <dl>
+          <div><dt>Low risk</dt><dd>{{ quality_audit.get('ghost_job_penalty', {}).get('low') | score_adjustment }}</dd></div>
+          <div><dt>Medium risk</dt><dd>{{ quality_audit.get('ghost_job_penalty', {}).get('medium') | score_adjustment }}</dd></div>
+          <div><dt>High risk</dt><dd>{{ quality_audit.get('ghost_job_penalty', {}).get('high') | score_adjustment }}</dd></div>
+        </dl>
+      </article>
+
+      <article class="risk-card">
+        <header>
+          <span class="risk-card-index">02</span>
+          <div>
+            <h3>Unfair process risk</h3>
+            <p>Excessive unpaid work, pressure, or one-sided candidate demands.</p>
+          </div>
+        </header>
+        <dl>
+          <div><dt>Low risk</dt><dd>{{ quality_audit.get('exploitation_penalty', {}).get('low') | score_adjustment }}</dd></div>
+          <div><dt>Medium risk</dt><dd>{{ quality_audit.get('exploitation_penalty', {}).get('medium') | score_adjustment }}</dd></div>
+          <div><dt>High risk</dt><dd>{{ quality_audit.get('exploitation_penalty', {}).get('high') | score_adjustment }}</dd></div>
+        </dl>
+      </article>
+
+      <article class="risk-card">
+        <header>
+          <span class="risk-card-index">03</span>
+          <div>
+            <h3>Delivery chaos risk</h3>
+            <p>Unclear ownership, constant urgency, or structurally unstable work.</p>
+          </div>
+        </header>
+        <dl>
+          <div><dt>Low risk</dt><dd>{{ quality_audit.get('chaos_penalty', {}).get('low') | score_adjustment }}</dd></div>
+          <div><dt>Medium risk</dt><dd>{{ quality_audit.get('chaos_penalty', {}).get('medium') | score_adjustment }}</dd></div>
+          <div><dt>High risk</dt><dd>{{ quality_audit.get('chaos_penalty', {}).get('high') | score_adjustment }}</dd></div>
+        </dl>
+      </article>
+    </div>
+
+    <div class="multi-risk-note">
+      <span>Extra caution</span>
+      <div>
+        <strong>Two or more high risks</strong>
+        <p>{{ quality_audit.get('multi_high_escalation') | score_adjustment }} in addition to the category deductions.</p>
+      </div>
+    </div>
   </div>
   {% else %}
   <div class="empty-state">

--- a/dashboard/templates/scoring.html
+++ b/dashboard/templates/scoring.html
@@ -1,82 +1,108 @@
 {% extends "base.html" %}
-{% block title %}Scoring — Job Search Workflow{% endblock %}
+{% block title %}Scoring · {{ product_name }}{% endblock %}
 {% block nav_scoring %}active{% endblock %}
 {% block content %}
-<div class="content-page">
-  <h1>Scoring Dashboard</h1>
+<section class="page-heading">
+  <div>
+    <p class="eyebrow">Decision support</p>
+    <h1>Scoring</h1>
+    <p class="page-summary">Review configuration and job signals. Scores support judgment; they do not replace it.</p>
+  </div>
+  <span class="read-only-badge">Config view</span>
+</section>
 
-  <h2>Quality Audit Penalties</h2>
+<section class="panel scoring-section">
+  <header class="panel-header">
+    <div>
+      <p class="eyebrow">Risk adjustments</p>
+      <h2>Quality audit penalties</h2>
+    </div>
+  </header>
   {% if quality_audit %}
-  <table class="scoring-table">
-    <tr>
-      <th>Category</th>
-      <th>Low</th>
-      <th>Medium</th>
-      <th>High</th>
-    </tr>
-    <tr>
-      <td>Ghost Job</td>
-      <td>{{ quality_audit.get('ghost_job_penalty', {}).get('low', '—') }}</td>
-      <td>{{ quality_audit.get('ghost_job_penalty', {}).get('medium', '—') }}</td>
-      <td>{{ quality_audit.get('ghost_job_penalty', {}).get('high', '—') }}</td>
-    </tr>
-    <tr>
-      <td>Exploitation</td>
-      <td>{{ quality_audit.get('exploitation_penalty', {}).get('low', '—') }}</td>
-      <td>{{ quality_audit.get('exploitation_penalty', {}).get('medium', '—') }}</td>
-      <td>{{ quality_audit.get('exploitation_penalty', {}).get('high', '—') }}</td>
-    </tr>
-    <tr>
-      <td>Chaos</td>
-      <td>{{ quality_audit.get('chaos_penalty', {}).get('low', '—') }}</td>
-      <td>{{ quality_audit.get('chaos_penalty', {}).get('medium', '—') }}</td>
-      <td>{{ quality_audit.get('chaos_penalty', {}).get('high', '—') }}</td>
-    </tr>
-    <tr>
-      <td>Multi-high escalation</td>
-      <td colspan="3">{{ quality_audit.get('multi_high_escalation', '—') }}</td>
-    </tr>
-  </table>
+  <div class="table-scroll" tabindex="0" aria-label="Quality audit penalties table">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th scope="col">Category</th>
+          <th scope="col">Low</th>
+          <th scope="col">Medium</th>
+          <th scope="col">High</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Ghost Job</th>
+          <td>{{ quality_audit.get('ghost_job_penalty', {}).get('low', '—') }}</td>
+          <td>{{ quality_audit.get('ghost_job_penalty', {}).get('medium', '—') }}</td>
+          <td>{{ quality_audit.get('ghost_job_penalty', {}).get('high', '—') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Exploitation</th>
+          <td>{{ quality_audit.get('exploitation_penalty', {}).get('low', '—') }}</td>
+          <td>{{ quality_audit.get('exploitation_penalty', {}).get('medium', '—') }}</td>
+          <td>{{ quality_audit.get('exploitation_penalty', {}).get('high', '—') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Chaos</th>
+          <td>{{ quality_audit.get('chaos_penalty', {}).get('low', '—') }}</td>
+          <td>{{ quality_audit.get('chaos_penalty', {}).get('medium', '—') }}</td>
+          <td>{{ quality_audit.get('chaos_penalty', {}).get('high', '—') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">Multi-high escalation</th>
+          <td colspan="3">{{ quality_audit.get('multi_high_escalation', '—') }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
   {% else %}
-  <p>No quality audit configuration found.</p>
+  <div class="empty-state">
+    <strong>No quality audit configuration</strong>
+    <p>Add the quality audit section to <code>config/scoring.yaml</code>.</p>
+  </div>
   {% endif %}
+</section>
 
-  <h2>Job Cards with Scores</h2>
+<section class="panel scoring-section">
+  <header class="panel-header">
+    <div>
+      <p class="eyebrow">Record signals</p>
+      <h2>Job scores</h2>
+    </div>
+    <span class="panel-meta">{{ cards | length }} records</span>
+  </header>
   {% if cards %}
-  <table class="scoring-table">
-    <tr>
-      <th>Title</th>
-      <th>Company</th>
-      <th>Stage</th>
-      <th>Fit Score</th>
-      <th>Quality Badge</th>
-      <th>Compensation</th>
-    </tr>
-    {% for card in cards %}
-    <tr>
-      <td><a href="/posting/{{ card.filename }}" style="color:var(--accent);text-decoration:none;">{{ card.title }}</a></td>
-      <td>{{ card.company }}</td>
-      <td>{{ card.stage }}</td>
-      <td>{{ card.fit_score if card.fit_score is not none else '—' }}</td>
-      <td>
-        {% if card.quality_badge and card.quality_badge != 'skipped' %}
-        <span class="badge badge-{{ card.quality_badge | replace('_', '-') }}">{{ card.quality_badge | replace('quality_', '') }}</span>
-        {% else %}
-        <span class="badge badge-quality-skipped">skipped</span>
-        {% endif %}
-      </td>
-      <td>
-        {% if card.compensation_signal and card.compensation_signal != 'unknown' %}
-        <span class="badge badge-compensation-{{ card.compensation_signal | replace('_', '-') }}">{{ card.compensation_signal | replace('_', ' ') }}</span>
-        {% else %}
-        <span class="badge badge-compensation-unknown">unknown</span>
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </table>
+  <div class="table-scroll" tabindex="0" aria-label="Job scores table">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th scope="col">Role</th>
+          <th scope="col">Company</th>
+          <th scope="col">Stage</th>
+          <th scope="col">Fit</th>
+          <th scope="col">Quality</th>
+          <th scope="col">Compensation</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for card in cards %}
+        <tr>
+          <th scope="row"><a class="table-link" href="/posting/{{ card.filename }}">{{ card.title }}</a></th>
+          <td>{{ card.company }}</td>
+          <td><span class="stage-marker stage-{{ card.stage }}">{{ card.stage | title }}</span></td>
+          <td>{{ card.fit_score if card.fit_score is not none else 'Not scored' }}</td>
+          <td>{{ card.quality_badge | replace('quality_', '') | replace('_', ' ') | title if card.quality_badge != 'skipped' else 'Not audited' }}</td>
+          <td>{{ card.compensation_signal | replace('_', ' ') | title if card.compensation_signal != 'unknown' else 'Not provided' }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   {% else %}
-  <p>No job cards found.</p>
+  <div class="empty-state">
+    <strong>No scored jobs</strong>
+    <p>Job records with scoring metadata will appear here.</p>
+  </div>
   {% endif %}
-</div>
+</section>
 {% endblock %}

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -1,9 +1,9 @@
-# Getting Started with Job Search Workflow
+# Getting Started with Job Search Workflow Community Edition
 
 This guide walks you through your first job triage, CV generation, and tracking
 — on macOS, Linux, or Windows.
 
-> **New here?** Read the [README](../README.md) first for the project overview.
+> **New here?** Read the [README](../../README.md) first for the project overview.
 
 ---
 
@@ -14,6 +14,7 @@ This guide walks you through your first job triage, CV generation, and tracking
 - [Your First Triage](#your-first-triage)
 - [Generate a Tailored CV](#generate-a-tailored-cv)
 - [Track in the Dashboard](#track-in-the-dashboard)
+- [Run Workflow Guards](#run-workflow-guards)
 - [Use the Career Pages Directory](#use-the-career-pages-directory)
 - [Next Steps](#next-steps)
 - [Troubleshooting](#troubleshooting)
@@ -29,7 +30,7 @@ You need:
 - **pdflatex** (for CV PDF generation)
 - **pandoc** (for DOCX generation)
 - **Git** (to clone the repo)
-- **Node.js** (optional, for markdown linting)
+- **Node.js 22.12+** (for extension tooling and repository checks)
 
 ### Install by Operating System
 
@@ -253,8 +254,9 @@ pandoc exports\your-cv.tex -o exports\your-cv.docx ^
 
 ## Track in the Dashboard
 
-The optional local dashboard turns your markdown files into a Kanban board
-and scoring view.
+The optional Community Operations Desk turns local Markdown files into a
+responsive overview, pipeline, searchable job inventory, profile view, and
+scoring reference.
 
 ### Start the Dashboard
 
@@ -270,14 +272,33 @@ Open `http://localhost:3000` in your browser.
 
 ### What You Can Do
 
-- View the **Kanban board**: new → triage → shortlist → applied → interview →
-  offer/reject
+- Review a compact **workspace overview** and attention list
+- View the responsive **pipeline**: new → triage → shortlist → applied →
+  interview → offer/reject
+- Search and filter the local **jobs inventory**
 - View your **profile**
 - Inspect **job postings**
-- See **scoring dashboard** with quality audit badges and compensation signals
+- Review **scoring configuration** and job signals
+- Choose a light or dark theme; light is the default
 
 The dashboard reads only from your local markdown files. No data leaves your
 machine.
+
+---
+
+## Run Workflow Guards
+
+Before saving or advancing a job record, use the read-only workflow guards to
+check duplicate identity, form-field limits, lifecycle metadata, and your own
+eligibility policy:
+
+```bash
+python3 scripts/workflow_guard.py --help
+```
+
+See the [Workflow Guards guide](WORKFLOW_GUARDS.md) for configuration examples
+and result meanings. The guards report problems but never submit an
+application, move a record, or make a decision for you.
 
 ---
 
@@ -348,7 +369,7 @@ the heading. The file contains explicit instructions for the AI.
 If you contribute changes, run:
 
 ```bash
-npx markdownlint-cli2 "**/*.md" "#node_modules"
+npx markdownlint-cli2 "**/*.md" "#**/node_modules/**"
 ```
 
 ---

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -46,7 +46,7 @@ brew install --cask mactex
 # Pandoc for DOCX
 brew install pandoc
 
-# Node.js (optional)
+# Node.js (required by repository setup and extension checks)
 brew install node
 
 # Verify
@@ -89,7 +89,7 @@ sudo dnf install python3 python3-pip git nodejs texlive-latex pandoc
    [TeX Live](https://tug.org/texlive/).
 4. **Pandoc**: Install from [pandoc.org](https://pandoc.org/installing.html)
    or with `winget install pandoc`.
-5. **Node.js** (optional): Download from [nodejs.org](https://nodejs.org) or
+5. **Node.js**: Download from [nodejs.org](https://nodejs.org) or
    run `winget install OpenJS.NodeJS` in PowerShell.
 
 Verify in PowerShell:
@@ -171,7 +171,7 @@ deal-breaker preferences.
 
 Copy a job posting that interests you. You can use:
 
-- The [Career Pages Directory](../data/career-pages/companies.yaml) for direct
+- The [Career Pages Directory](../../data/career-pages/companies.yaml) for direct
   company career pages
 - LinkedIn, Indeed, or any public job board
 - A job posting someone shared with you
@@ -234,20 +234,22 @@ pdflatex -output-directory=exports exports\your-cv.tex
 
 ### Export to DOCX
 
-For a DOCX version, use `pandoc` with the reference template:
+The repository does not bundle a personal DOCX style template. Place a template
+you have the right to use at `exports/cv-reference.docx`, save the generated CV
+content as `exports/your-cv.md`, and run:
 
 ```bash
 # macOS / Linux
-pandoc exports/your-cv.tex -o exports/your-cv.docx \
-  --reference-doc=templates/cv-reference.docx
+pandoc exports/your-cv.md -o exports/your-cv.docx \
+  --reference-doc=exports/cv-reference.docx
 
 # Windows (PowerShell)
-pandoc exports\your-cv.tex -o exports\your-cv.docx `
-  --reference-doc=templates\cv-reference.docx
+pandoc exports\your-cv.md -o exports\your-cv.docx `
+  --reference-doc=exports\cv-reference.docx
 
 # Windows (CMD)
-pandoc exports\your-cv.tex -o exports\your-cv.docx ^
-  --reference-doc=templates\cv-reference.docx
+pandoc exports\your-cv.md -o exports\your-cv.docx ^
+  --reference-doc=exports\cv-reference.docx
 ```
 
 ---
@@ -281,8 +283,9 @@ Open `http://localhost:3000` in your browser.
 - Review **scoring configuration** and job signals
 - Choose a light or dark theme; light is the default
 
-The dashboard reads only from your local markdown files. No data leaves your
-machine.
+The dashboard reads only from your local Markdown files and does not transmit
+them. A separate cloud AI assistant may process anything you choose to paste
+into that service, so review its privacy terms independently.
 
 ---
 
@@ -337,7 +340,7 @@ pull request. See `data/career-pages/README.md` for the schema.
 | Optimize LinkedIn | `modes/03_LINKEDIN_PROFILE.md` |
 | Draft recruiter messages | `modes/04_RECRUITER_OUTREACH.md` |
 | Find job sources | `modes/06_PUBLIC_SOURCE_DISCOVERY.md` |
-| Contribute | [CONTRIBUTING.md](../CONTRIBUTING.md) |
+| Contribute | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 
 ---
 
@@ -382,3 +385,7 @@ personal information to the repository.
 
 If you want to back up your data, copy the directories above to a private
 location outside the repository.
+
+Community Edition is source-available for noncommercial use. Read
+[Commercial Use and SaaS Boundary](../../COMMERCIAL_USE.md) before sharing,
+redistributing, or integrating the code into another product.

--- a/docs/getting-started/WORKFLOW_GUARDS.md
+++ b/docs/getting-started/WORKFLOW_GUARDS.md
@@ -1,0 +1,105 @@
+# Workflow Guards
+
+Job Search Workflow Community Edition includes read-only guards for common
+local workflow mistakes. The guards report evidence; they do not capture jobs,
+move files, change lifecycle state, or submit applications.
+
+## Result Contract
+
+Every command prints JSON with:
+
+- `check`: the guard that ran
+- `status`: `PASS`, `FAIL`, `REVIEW`, or `BLOCKED`
+- `summary`: a short explanation
+- `details`: exact fields or records that need attention
+
+Exit codes are:
+
+| Exit | Status | Meaning |
+| --- | --- | --- |
+| `0` | `PASS` | The configured check passed. |
+| `1` | `FAIL` | Evidence conflicts with the configured rule. |
+| `2` | `BLOCKED` | Input or configuration is incomplete or invalid. |
+| `3` | `REVIEW` | A human needs to resolve an unknown value. |
+
+## Duplicate Check
+
+Check a candidate before adding a new Markdown record:
+
+```bash
+python3 scripts/workflow_guard.py duplicate \
+  --jobs-dir inbox/jobs \
+  --company "Example Labs" \
+  --role-title "Platform Engineer" \
+  --location "Remote" \
+  --work-model "remote" \
+  --source-url "https://example.com/jobs/42"
+```
+
+The guard compares a normalized source URL and, when complete, the combined
+company, role, location, and work-model identity. Tracking-only query
+parameters are removed, while identity-bearing parameters such as a job ID are
+retained.
+
+## Form Field Limits
+
+Define application fields in YAML. See
+`fixtures/sample-form-fields.yaml`. Each field uses a stable ID, the exact
+level-two Markdown heading, a required flag, and an optional character limit.
+
+```bash
+python3 scripts/workflow_guard.py form-limits \
+  --schema fixtures/sample-form-fields.yaml \
+  --answers fixtures/sample-application-answers.md
+```
+
+The command reports missing required answers and answers that exceed the
+configured character limit.
+
+## Lifecycle Metadata
+
+The default lifecycle contract is `config/lifecycle.yaml`. Users may copy and
+change it for their own local workflow.
+
+```bash
+python3 scripts/workflow_guard.py lifecycle \
+  --policy config/lifecycle.yaml \
+  --jobs-dir inbox/jobs
+```
+
+The guard verifies that each recognized Markdown record has a known
+`triage_state` and the fields required by that state. It never moves active or
+closed records.
+
+## Eligibility Policy
+
+Copy `config/eligibility.example.yaml` to a Git-ignored user location and
+replace the sample regions with your own work-authorization and relocation
+policy.
+
+A job record may provide:
+
+```yaml
+hiring_region: europe
+sponsorship_required: false
+sponsorship_provided: false
+relocation_required: false
+```
+
+Run:
+
+```bash
+python3 scripts/workflow_guard.py eligibility \
+  --policy user_data/eligibility.yaml \
+  --job inbox/jobs/example-role.md
+```
+
+Eligibility is deliberately configurable. The repository does not assume a
+home country, citizenship, visa status, or willingness to relocate. Unknown
+hiring or sponsorship evidence returns `REVIEW`, not an invented decision.
+
+## Privacy Boundary
+
+Policies under `user_data/` and records under `inbox/` are Git-ignored.
+Do not commit personal eligibility settings, real application answers, or job
+history to the public repository.

--- a/docs/integration/job-search-workflow.md
+++ b/docs/integration/job-search-workflow.md
@@ -169,9 +169,9 @@ GET /captures?since=2026-07-25T00:00:00+00:00
 
 ## Normalized Posting Schema
 
-The Markdown file written to `inbox/jobs/` has English front-matter and
-Turkish prose sections to match Job Search Workflow capture conventions
-(GAP-20260622-02).
+The Markdown file written to `inbox/jobs/` has English front-matter and English
+sample prose. User-created local prose may use the language preferred by the
+workspace owner.
 
 ```markdown
 ---
@@ -216,9 +216,9 @@ Strong SRE background alignment.
 
 ### Free-form sections
 
-- `## Why Captured` — Turkish prose explaining why the posting was captured.
+- `## Why Captured` — prose explaining why the posting was captured.
 - `## Extracted Facts` — bullet list of structured facts extracted during capture.
-- `## Fit Hypothesis` — Turkish prose describing the initial fit hypothesis.
+- `## Fit Hypothesis` — prose describing the initial fit hypothesis.
 
 ## Deduplication
 

--- a/docs/integration/job-search-workflow.md
+++ b/docs/integration/job-search-workflow.md
@@ -1,8 +1,9 @@
 # Job Search Workflow Integration Contract
 
 This document defines how the `Job Search Workflow Capture` browser extension,
-the `public/scripts/linkedin_capture_server.py` FastAPI capture server, and the
-Job Search Workflow `inbox/jobs/` triage/decision/export pipeline fit together.
+the `scripts/linkedin_capture_server.py` FastAPI capture server, and the Job
+Search Workflow Community Edition `inbox/jobs/` triage/decision/export pipeline
+fit together.
 
 ## Scope
 
@@ -234,19 +235,19 @@ Environment variables:
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `CAREEROPS_INBOX_DIR` | `inbox/jobs` | Directory where capture Markdown files are written. |
-| `CAREEROPS_CAPTURE_PORT` | `8766` | Port the FastAPI server listens on. `CAREEROPS_LINKEDIN_CAPTURE_PORT` is accepted as a legacy fallback. |
+| `JSW_INBOX_DIR` | `inbox/jobs` | Directory where capture Markdown files are written. |
+| `JSW_CAPTURE_PORT` | `8766` | Port the FastAPI server listens on. |
 
 Start the server:
 
 ```bash
-python3 public/scripts/linkedin_capture_server.py
+python3 scripts/linkedin_capture_server.py
 ```
 
 Or with a custom inbox directory:
 
 ```bash
-CAREEROPS_INBOX_DIR=/path/to/inbox/jobs python3 public/scripts/linkedin_capture_server.py
+JSW_INBOX_DIR=/path/to/inbox/jobs python3 scripts/linkedin_capture_server.py
 ```
 
 ## Extension ↔ Server Wiring

--- a/docs/policies/public-surface-sanitization.md
+++ b/docs/policies/public-surface-sanitization.md
@@ -1,119 +1,115 @@
 # Public Surface Sanitization Policy
 
-This policy defines how the Job Search Workflow repository produces a clean, reusable,
-public-facing surface under `public/`. It covers source code, documentation,
-fixtures, CI configuration, and release artifacts.
+This policy defines how Job Search Workflow Community Edition keeps its
+standalone repository reusable, local-first, and free from unintended personal
+or private material.
 
 ## Scope
 
-The public surface includes everything that may be copied into a separate public
-repository or released as a standalone artifact:
+The entire repository is public surface, including:
 
-- `public/tools/browser-extension/`
-- `public/scripts/`
-- `public/tests/`
-- `public/docs/`
-- `public/.github/workflows/`
-- `public/README.md` and `public/PUBLISH_CHECKLIST_EXTENSION.md`
+- source code under `dashboard/`, `scripts/`, and `tools/`
+- tests and fictitious fixtures
+- documentation and templates
+- CI configuration and release artifacts
+- root metadata such as `README.md` and `pyproject.toml`
+
+Generated dependency trees, Git internals, caches, and binary release artifacts
+are excluded from content scanning only when their source manifest or build
+input remains scanned.
 
 ## Hard Constraints
 
-### 1. No Personal Data or Private References
+### 1. No Unintended Personal Data
 
 Public artifacts MUST NOT contain:
 
-- Real names, email addresses, phone numbers, or national ID numbers.
-- Personal addresses, home directory paths, or usernames tied to the owner.
-- Private repository slugs, internal endpoints, or unpublished prompts.
-- Placeholder usernames such as `kullaniciadi` or `orcun`.
+- private email addresses, phone numbers, national identifiers, or addresses
+- owner home-directory paths or private repository slugs
+- credentials, tokens, internal endpoints, or unpublished prompts
+- real job-search records, application history, CVs, or decision records
 
-### 2. No Owner-Specific Defaults
+Fictitious fixture identities and GitHub noreply maintainer addresses are
+allowed. The maintainer's public name may appear in package metadata.
 
-Public templates, fixtures, and default settings MUST NOT encode owner
-preferences:
+### 2. Community Edition Naming
 
-- Minimum salary defaults MUST be `null` or a clearly fictitious value.
-- Location defaults MUST be generic (e.g. `Remote, Berlin`) not tied to the
-  owner.
-- Company-origin filters MUST default to neutral (`any`) in public templates.
-- `Job Search Workflow` is the public framework name; profile labels MUST use
-  `Example Job Search Workflow Profile` or a similarly generic label.
+- The user-facing framework name is `Job Search Workflow Community Edition`.
+- `JSW Community Edition` may be used where space is constrained.
+- The browser extension component remains `Job Search Workflow Capture`.
+- Environment variables use the `JSW_` prefix.
+- Retired private product names and owner-specific framework identifiers MUST
+  NOT appear anywhere in the standalone repository.
+- The CLI command remains `jsw`; this is a technical command, not a separate
+  product name.
 
-### 3. Brand and Trademark Boundaries
+### 3. No Owner-Specific Defaults
 
-- The public product name for the browser extension is
-  `Job Search Workflow Capture`.
-- `LinkedIn` MAY appear in descriptions, help text, target-site URLs, and
-  host permissions because the extension operates on LinkedIn Jobs.
-- `LinkedIn` MUST NOT be used as the main product name in `manifest.json`,
-  `package.json`, popup/options titles, or README level-one heading.
-- Private repo slugs such as `linkedin-job-filter` or any owner-specific
-  framework slug MUST NOT appear in public files.
-- Source identifiers and capture method names MUST use generic identifiers such
-  as `job-search-workflow-capture` / `job_search_workflow_capture`, not
-  `linkedin-manual-extension` or `linkedin_manual_extension_capture`.
+Public templates, fixtures, and default settings MUST NOT encode a maintainer's
+personal preferences:
 
-### 4. Language Rule for Public UI
+- compensation defaults are null or explicitly fictitious
+- location defaults are generic and belong only to sample fixtures
+- company filters default to neutral values
+- eligibility, work authorization, and relocation rules are user-configurable
 
-All user-facing strings in the public extension MUST be in English:
+### 4. Brand and Trademark Boundaries
 
-- HTML `lang` attribute MUST be `en`.
-- UI labels, button text, placeholders, console comments, and test log
-  messages MUST be English.
-- Regex-based keyword detection MUST use English terms only (e.g. `remote`,
-  `hybrid`, `office`, `onsite`).
+- LinkedIn may appear in descriptions, help text, supported-site URLs, and host
+  permissions where the extension actually integrates with LinkedIn Jobs.
+- LinkedIn MUST NOT be used as the extension's main product name.
+- Capture identifiers use generic JSW names rather than private or
+  owner-specific identifiers.
 
-Internal comments and variable names MAY remain English; Turkish comments MUST
-be translated before public release.
+### 5. Language Rule
 
-### 5. Inbox Capture Language Rule
-
-`inbox/jobs/` capture Markdown follows GAP-20260622-02:
-
-- Structural front-matter fields are English for machine readability.
-- Free-form prose sections are Turkish unless a downstream consumer requires
-  otherwise.
+User-facing Community Edition strings and public documentation are English.
+Machine-readable source fields remain English. User-created local content may
+use any language supported by the user's own workflow.
 
 ## Pre-Flight Checklist
 
 Before any public commit, pull request, or release:
 
-1. Run `npm test` in `public/tools/browser-extension/` and confirm full parity.
-2. Run `npm run lint` in `public/tools/browser-extension/`.
-3. Run `node scripts/validate-manifest.js` in `public/tools/browser-extension/`.
-4. Run `python3 -m pytest public/tests/test_linkedin_capture_server.py -q`.
-5. Run `python3 public/scripts/scan_pii.py`.
-6. Run `python3 public/scripts/check_linkedin_brand.py`.
-7. Run `npx markdownlint-cli2` on changed Markdown files.
-8. Review the diff manually for owner-specific strings, old private slugs, or
-   leftover Turkish UI text.
+1. Run `npm ci`, `npm run lint`, `npm test`, and
+   `node scripts/validate-manifest.js` under `tools/browser-extension/`.
+2. Run `npm audit --audit-level=high` under `tools/browser-extension/`.
+3. Run `python3 -m pytest -q`.
+4. Run `python3 scripts/scan_pii.py --path .`.
+5. Run `python3 scripts/check_secret_hygiene.py`.
+6. Run `python3 scripts/check_linkedin_brand.py`.
+7. Run `python3 scripts/verify_no_turkish.py --path .`.
+8. Run `npx markdownlint-cli2 "**/*.md" "#**/node_modules/**"`.
+9. Review the diff and reachable Git metadata for unintended private material.
 
 ## CI Enforcement
 
-`public/.github/workflows/clone-scan.yml` runs the above checks in separate
-jobs. Any failure blocks the workflow.
+`.github/workflows/ci.yml` runs deterministic pull-request checks. Scheduled
+setup, career-page, and clone scans are separate because they validate
+operational drift rather than duplicate the pull-request test suite.
+
+A passing file scan proves only that configured patterns found no match in the
+scanned tree. It does not prove that copies, forks, caches, or unrelated Git
+history are erased.
 
 ## Release Policy
 
-- Phase 1 `.zip` releases require explicit human approval after the checklist
-  is complete.
-- Chrome Web Store (Phase 2) is out of scope for this policy and requires a
-  separate approval.
-- No `git push` to a public remote may happen without a passing guardian audit
-  and, where required, the user's explicit sign-off.
+- GitHub releases require explicit human approval after the checklist passes.
+- Chrome Web Store publication remains separately scoped and approved.
+- Public pushes must use a GitHub noreply commit address and pass the repository
+  privacy checks.
 
 ## Tools
 
-- `public/scripts/scan_pii.py` — fail-closed scanner for hard PII and private
+- `scripts/scan_pii.py` scans an explicit root for personal and private
   references.
-- `public/scripts/check_linkedin_brand.py` — fail-closed check that LinkedIn
-  is not used as the main product name.
-- `npx markdownlint-cli2` — Markdown linting.
-- `npm test` and `npm run lint` — extension tests and static checks.
-- `pytest` and `py_compile` — Python server checks.
+- `scripts/check_secret_hygiene.py` scans for common credential formats.
+- `scripts/check_linkedin_brand.py` enforces extension brand boundaries.
+- `scripts/verify_no_turkish.py` checks public-facing language consistency.
+- `pytest`, `npm test`, and browser smoke checks cover runtime behavior.
 
 ## References
 
-- `public/PUBLISH_CHECKLIST_EXTENSION.md`
-- `public/tools/browser-extension/tests/fixtures/SANITIZATION_INVENTORY.md`
-- `AGENTS.md` GAP-20260622-02
+- `PUBLISH_CHECKLIST_EXTENSION.md`
+- `.github/workflows/ci.yml`
+- `docs/setup-and-verification.md`

--- a/docs/policies/public-surface-sanitization.md
+++ b/docs/policies/public-surface-sanitization.md
@@ -67,6 +67,21 @@ User-facing Community Edition strings and public documentation are English.
 Machine-readable source fields remain English. User-created local content may
 use any language supported by the user's own workflow.
 
+### 6. License and Commercial Boundary
+
+- Community Edition is source-available under PolyForm Noncommercial 1.0.0; it
+  MUST NOT be described as OSI-approved open source.
+- The canonical `LICENSE` MUST remain byte-identical to the official PolyForm
+  Noncommercial 1.0.0 plain text. Owner-specific notices belong in `NOTICE`.
+- All first-party packages and release archives MUST carry the same
+  noncommercial license identity and include `LICENSE` plus `NOTICE`.
+- Commercial use requires a separate written agreement from the copyright
+  holder. Community Edition does not grant rights to the separate private SaaS
+  product, hosted infrastructure, private code, customer data, or non-public
+  assets.
+- Dependency license metadata describes third-party dependencies only and MUST
+  NOT be presented as the license for first-party Community Edition code.
+
 ## Pre-Flight Checklist
 
 Before any public commit, pull request, or release:
@@ -80,7 +95,8 @@ Before any public commit, pull request, or release:
 6. Run `python3 scripts/check_linkedin_brand.py`.
 7. Run `python3 scripts/verify_no_turkish.py --path .`.
 8. Run `npx markdownlint-cli2 "**/*.md" "#**/node_modules/**"`.
-9. Review the diff and reachable Git metadata for unintended private material.
+9. Run `python3 scripts/check_license_policy.py`.
+10. Review the diff and reachable Git metadata for unintended private material.
 
 ## CI Enforcement
 

--- a/docs/runbooks/browser-extension-install.md
+++ b/docs/runbooks/browser-extension-install.md
@@ -20,8 +20,8 @@ mode. This runbook covers the load-unpacked flow used for Phase 1 releases.
 
 3. Click **Load unpacked**.
 
-4. Select the `tools/browser-extension/` directory (or the extracted
-   `.zip` release folder).
+4. Select the `tools/browser-extension/` directory. An extracted `.zip` folder
+   is also valid after an approved release archive exists.
 
 5. The extension appears in the extensions list as `Job Search Workflow Capture`.
 
@@ -117,17 +117,18 @@ The server writes one Markdown file per posting to `inbox/jobs/`, deduplicating 
 
 ### LinkedIn shows a challenge page
 
-- Reduce scan speed to `Conservative`.
-- Increase the delay values in the speed profile.
-- Avoid unattended scans on the same account too frequently.
+- Stop the scan and do not attempt to bypass the challenge.
+- Continue manually only when the site's normal access flow and terms permit
+  it.
 
 ## Update the extension
 
-1. Download the latest `.zip` release.
-2. Extract it to a folder.
-3. In `chrome://extensions`, find the existing extension and click **Remove**.
-4. Click **Load unpacked** and select the extracted folder.
+1. Export settings from the options page.
+2. Update the cloned repository with Git, or download an approved release
+   archive when one is published.
+3. Return to `chrome://extensions` and click **Reload** on the extension card.
+4. If the source directory changed, remove the extension and load the new
+   directory unpacked.
 
-Your options are stored in `chrome.storage.local`; they are lost when the
-extension is removed. Use **Export Settings** in the options page before
-removing.
+Removing the extension may clear `chrome.storage.local`; import the settings
+backup after reinstalling.

--- a/docs/runbooks/browser-extension-install.md
+++ b/docs/runbooks/browser-extension-install.md
@@ -6,7 +6,7 @@ mode. This runbook covers the load-unpacked flow used for Phase 1 releases.
 ## Prerequisites
 
 - Chrome, Chromium, Brave, or another Chromium-based browser.
-- Extension source files in `public/tools/browser-extension/`.
+- Extension source files in `tools/browser-extension/`.
 
 ## Install steps
 
@@ -20,7 +20,7 @@ mode. This runbook covers the load-unpacked flow used for Phase 1 releases.
 
 3. Click **Load unpacked**.
 
-4. Select the `public/tools/browser-extension/` directory (or the extracted
+4. Select the `tools/browser-extension/` directory (or the extracted
    `.zip` release folder).
 
 5. The extension appears in the extensions list as `Job Search Workflow Capture`.

--- a/docs/runbooks/capture-server-setup.md
+++ b/docs/runbooks/capture-server-setup.md
@@ -1,6 +1,6 @@
 # Capture Server Setup Runbook
 
-The `public/scripts/linkedin_capture_server.py` FastAPI server receives job
+The `scripts/linkedin_capture_server.py` FastAPI server receives job
 postings from the `Job Search Workflow Capture` extension and writes them as
 Markdown files to `inbox/jobs/`.
 
@@ -30,7 +30,7 @@ python3 -m pip install fastapi pydantic pyyaml uvicorn
 Default port `8766` and default inbox directory `inbox/jobs`:
 
 ```bash
-python3 public/scripts/linkedin_capture_server.py
+python3 scripts/linkedin_capture_server.py
 ```
 
 You should see output similar to:
@@ -48,7 +48,7 @@ The server creates the inbox directory if it does not exist. Set a custom path
 with the environment variable:
 
 ```bash
-CAREEROPS_INBOX_DIR=/path/to/inbox/jobs python3 public/scripts/linkedin_capture_server.py
+JSW_INBOX_DIR=/path/to/inbox/jobs python3 scripts/linkedin_capture_server.py
 ```
 
 ## Configure port
@@ -56,11 +56,11 @@ CAREEROPS_INBOX_DIR=/path/to/inbox/jobs python3 public/scripts/linkedin_capture_
 The default port is `8766`. Override it with:
 
 ```bash
-CAREEROPS_CAPTURE_PORT=9000 python3 public/scripts/linkedin_capture_server.py
+JSW_CAPTURE_PORT=9000 python3 scripts/linkedin_capture_server.py
 ```
 
-The legacy variable `CAREEROPS_LINKEDIN_CAPTURE_PORT` is also accepted for
-backward compatibility.
+Environment variables use the `JSW_` prefix consistently across the Community
+Edition surface.
 
 ## Verify the server
 
@@ -130,14 +130,14 @@ curl -X POST http://localhost:8766/batch \
 For long-running unattended scans, use a process manager:
 
 ```bash
-nohup python3 public/scripts/linkedin_capture_server.py > logs/capture-server.log 2>&1 &
+nohup python3 scripts/linkedin_capture_server.py > logs/capture-server.log 2>&1 &
 ```
 
 Or use `tmux`:
 
 ```bash
 tmux new -s capture-server
-python3 public/scripts/linkedin_capture_server.py
+python3 scripts/linkedin_capture_server.py
 ```
 
 Detach with `Ctrl+b` then `d`.
@@ -162,12 +162,12 @@ Install the dependencies listed in the prerequisites section.
 ### `Permission denied: inbox/jobs`
 
 The server tries to create `inbox/jobs` relative to the current working
-directory. Ensure the process has write permission or set `CAREEROPS_INBOX_DIR`
+directory. Ensure the process has write permission or set `JSW_INBOX_DIR`
 to a writable path.
 
 ### `Address already in use`
 
-Another process is using port `8766`. Stop it or set `CAREEROPS_CAPTURE_PORT` to
+Another process is using port `8766`. Stop it or set `JSW_CAPTURE_PORT` to
 a different port. Update the extension options to match.
 
 ### Captures are not appearing in `inbox/jobs/`

--- a/docs/runbooks/capture-server-setup.md
+++ b/docs/runbooks/capture-server-setup.md
@@ -14,7 +14,7 @@ Markdown files to `inbox/jobs/`.
 From the public repository root:
 
 ```bash
-python3 -m pip install fastapi pydantic pyyaml uvicorn
+python3 -m pip install -e ".[dashboard]"
 ```
 
 Or use a virtual environment:
@@ -22,7 +22,7 @@ Or use a virtual environment:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-python3 -m pip install fastapi pydantic pyyaml uvicorn
+python3 -m pip install -e ".[dashboard]"
 ```
 
 ## Start the server
@@ -130,6 +130,7 @@ curl -X POST http://localhost:8766/batch \
 For long-running unattended scans, use a process manager:
 
 ```bash
+mkdir -p logs
 nohup python3 scripts/linkedin_capture_server.py > logs/capture-server.log 2>&1 &
 ```
 

--- a/docs/runbooks/source-discovery-operations.md
+++ b/docs/runbooks/source-discovery-operations.md
@@ -1,0 +1,40 @@
+# Source Discovery Operations
+
+## Purpose
+
+Use public sources to find candidate postings, verify them manually, and save
+factual local records for later triage. This flow does not apply, submit, or
+make a career decision automatically.
+
+## Inputs
+
+- Your local `user_data/target_roles.md`
+- [Public Job Sources](../sources/public-job-sources.md)
+- [Source Discovery Query Pack](../sources/source-discovery-query-pack.md)
+- A browser for checking the employer or ATS page
+
+## Workflow
+
+1. Read your target roles, required criteria, and avoid signals.
+2. Choose one public source and one bounded query.
+3. Open each result in the browser and confirm the role-specific page is live.
+4. Record the title, company, location, work model, source URL, and check date.
+5. Save the posting under `inbox/jobs/` using a clear Markdown filename.
+6. Run `python3 scripts/workflow_guard.py --help` and select the relevant
+   read-only checks.
+7. Use `modes/01_JOB_TRIAGE.md` for the manual decision step.
+
+## Safety Boundary
+
+- Do not bypass authentication, paywalls, bot challenges, rate limits, or
+  access controls.
+- Do not store cookies, tokens, sessions, or unrelated personal data.
+- Do not treat a search snippet as proof that a posting is still live.
+- Do not auto-apply or promote a posting to an application state.
+- Keep personal criteria and captured postings in gitignored local folders.
+
+## Completion Record
+
+For each discovery pass, record the source, query, check date, number reviewed,
+number saved, and any access limitation. A zero-result pass is still useful when
+the query and boundary are recorded honestly.

--- a/docs/setup-and-verification.md
+++ b/docs/setup-and-verification.md
@@ -35,7 +35,7 @@ The check validates these required components:
 - `README.md` and `.gitignore`
 - Git
 - Python 3.10 or newer
-- Node.js 18 or newer
+- Node.js 22.12 or newer
 - npm
 
 The Linux/macOS script also reports the optional `pandoc`, `pdflatex` and `markdownlint-cli2` tools. Missing optional tools do not block the basic setup, but the related document-export or lint capability will be unavailable.
@@ -99,7 +99,7 @@ Run these commands from the public repository root:
 bash -n scripts/setup.sh
 shellcheck scripts/setup.sh
 python3 -m unittest discover -s tests -v
-python3 -m pytest public/tests/test_linkedin_capture_server.py -q
+python3 -m pytest tests/test_linkedin_capture_server.py -q
 markdownlint-cli2 "**/*.md"
 ./scripts/setup.sh --check-only
 ./scripts/setup.sh

--- a/docs/setup-and-verification.md
+++ b/docs/setup-and-verification.md
@@ -80,6 +80,7 @@ mode:
 
    ```bash
    cd tools/browser-extension
+   npm ci
    npm test
    npm run lint
    node scripts/validate-manifest.js
@@ -99,7 +100,11 @@ Run these commands from the public repository root:
 bash -n scripts/setup.sh
 shellcheck scripts/setup.sh
 python3 -m unittest discover -s tests -v
-python3 -m pytest tests/test_linkedin_capture_server.py -q
+python3 -m pytest -q
+PYTHONPATH=scripts python3 -m jsw smoke
+python3 scripts/scan_pii.py --path .
+python3 scripts/check_secret_hygiene.py
+python3 scripts/check_license_policy.py
 markdownlint-cli2 "**/*.md"
 ./scripts/setup.sh --check-only
 ./scripts/setup.sh
@@ -108,12 +113,19 @@ git diff --check
 
 ## CI Evidence
 
-`.github/workflows/clone-scan.yml` runs independent jobs for:
+`.github/workflows/ci.yml` runs pull-request and `main` checks for Python,
+dashboard behavior, privacy, documentation, and the browser extension.
+
+`.github/workflows/setup-audit.yml` runs independent scheduled/manual jobs for:
 
 - Linux: Bash syntax, ShellCheck, Markdown lint, Python behavior tests and a full setup smoke test.
 - Windows: a full `setup.bat` smoke test under real `cmd.exe`.
 
-Required workflow steps do not suppress failures. A lint, test or setup failure fails the job.
+`.github/workflows/clone-scan.yml` is a separate scheduled/manual repository
+discovery check; it is not setup or pull-request CI evidence.
+
+Required workflow steps do not suppress failures. A lint, test or setup failure
+fails the owning job.
 
 ## Behavior Tests
 
@@ -133,7 +145,7 @@ Required workflow steps do not suppress failures. A lint, test or setup failure 
 
 - `Missing required tools`: Install the listed tools through a trusted package manager, then run `--check-only` again.
 - `Python >= 3.10 is required`: Correct the active `python3` or `python` installation.
-- `Node.js >= 18 is required`: Switch to a supported Node.js LTS release.
+- `Node.js >= 22.12 is required`: Switch to Node.js 22.12 or newer.
 - Markdown lint failure: Correct the reported files instead of converting the failure into a warning.
 - Windows CI failure: Fix the first failing command in the relevant GitHub Actions log. A Linux pass is not evidence of Windows compatibility.
 

--- a/docs/sources/source-discovery-query-pack.md
+++ b/docs/sources/source-discovery-query-pack.md
@@ -1,0 +1,46 @@
+# Source Discovery Query Pack
+
+Use these templates to find public job postings without bypassing access
+controls, login walls, rate limits, or site terms. Replace bracketed values with
+your own criteria.
+
+## Search Templates
+
+### Company Career Pages
+
+```text
+site:[company-career-domain] ("[target role]" OR "[adjacent role]")
+```
+
+### Public ATS Pages
+
+```text
+site:boards.greenhouse.io OR site:jobs.ashbyhq.com OR site:jobs.lever.co
+"[target role]" "[location or remote region]"
+```
+
+### Skills and Work Model
+
+```text
+"[target role]" "[required skill]" (remote OR hybrid) "[region]"
+```
+
+### Exclusion Pass
+
+```text
+"[target role]" "[region]" -intern -contract -"[excluded technology]"
+```
+
+## Review Checklist
+
+1. Prefer the employer's official career page over search snippets.
+2. Confirm that the posting title, location, and apply action are present.
+3. Record the source URL and the date you checked it.
+4. Save only the facts needed for your local workflow.
+5. Run the read-only workflow guards before manual triage.
+6. Stop if the site blocks access or requires automation that its terms do not
+   permit.
+
+See [Public Job Sources](public-job-sources.md) for starting points and
+[Source Discovery Operations](../runbooks/source-discovery-operations.md) for
+the complete local flow.

--- a/fixtures/demo-01-signal-grove-ai-tools.md
+++ b/fixtures/demo-01-signal-grove-ai-tools.md
@@ -1,0 +1,41 @@
+---
+source_id: demo-001
+source_url: https://example.com/careers/ai-developer-tools-engineer
+captured_at: 2026-08-18
+company: Signal Grove
+role_title: AI Developer Tools Engineer
+location: Remote (Europe and UK)
+work_model: remote
+source_class: company_careers_page
+capture_method: manual_snapshot
+triage_state: captured
+initial_fit_score_value: 4.6
+---
+
+## Why Captured
+
+The role combines developer productivity, agentic coding workflows, and platform engineering in a remote-first product team.
+
+## Extracted Facts
+
+- **Team:** Developer Experience, 11 engineers across four time zones
+- **Scope:** Build coding-agent evaluation, repository automation, and internal platform APIs
+- **Stack:** Python, TypeScript, FastAPI, PostgreSQL, GitHub Actions, OpenTelemetry
+- **Salary:** EUR 92,000-118,000 plus equity
+- **Work model:** Remote within Europe and the UK, two annual team gatherings
+- **Interview:** Portfolio review, take-home architecture exercise, and team conversation
+
+## Fit Hypothesis
+
+Excellent match for AI-assisted engineering workflow and platform ownership. The main open point is whether employment from every listed country is supported.
+
+## Quality Signals
+
+- quality_badge: `quality_green`
+- quality_audit_recommendation: `proceed`
+- compensation_signal: `transparent_aligned`
+
+## Open Questions
+
+- Which countries are supported through direct employment or an employer of record?
+- How much of the role is product engineering versus internal enablement?

--- a/fixtures/demo-02-harborline-llm-platform.md
+++ b/fixtures/demo-02-harborline-llm-platform.md
@@ -1,0 +1,41 @@
+---
+source_id: demo-002
+source_url: https://example.com/careers/senior-backend-llm-platform
+captured_at: 2026-08-17
+company: Harborline Systems
+role_title: Senior Backend Engineer - LLM Platform
+location: Remote (EMEA)
+work_model: remote
+source_class: company_careers_page
+capture_method: browser_snapshot
+initial_decision: triage
+initial_fit_score_value: 4.1
+---
+
+## Why Captured
+
+The team is building a multi-model orchestration layer for enterprise support workflows, with explicit ownership of reliability and evaluation.
+
+## Extracted Facts
+
+- **Product:** LLM routing, retrieval, guardrails, and offline evaluation services
+- **Stack:** Python, FastAPI, PostgreSQL, Redis, Kubernetes, OpenTelemetry
+- **Scale:** 35 million model requests per month across three regions
+- **Salary:** EUR 85,000-105,000
+- **On-call:** Business-hours rotation, one week every eight weeks
+- **Interview:** Technical discussion, async code exercise, systems design
+
+## Fit Hypothesis
+
+Strong backend and AI workflow fit. Production retrieval depth and the exact incident burden need closer review before promotion.
+
+## Quality Signals
+
+- quality_badge: `quality_green`
+- quality_audit_recommendation: `proceed`
+- compensation_signal: `transparent_aligned`
+
+## Open Questions
+
+- Is the rotation strictly business hours in the employee's time zone?
+- What percentage of traffic uses retrieval versus direct model calls?

--- a/fixtures/demo-03-northstar-platform.md
+++ b/fixtures/demo-03-northstar-platform.md
@@ -1,0 +1,41 @@
+---
+source_id: demo-003
+source_url: https://example.com/careers/staff-platform-engineer-ai-systems
+captured_at: 2026-08-15
+company: Northstar Compute
+role_title: Staff Platform Engineer - AI Systems
+location: Berlin or Remote EU
+work_model: remote_first
+source_class: company_careers_page
+capture_method: browser_snapshot
+triage_state: triaged_conditional
+initial_fit_score_value: 4.4
+---
+
+## Why Captured
+
+This is a high-ownership platform role supporting model-serving teams with clear technical leadership scope and no people-management requirement.
+
+## Extracted Facts
+
+- **Scope:** Golden paths for model deployment, GPU scheduling, and service reliability
+- **Stack:** Go, Python, Kubernetes, Terraform, Argo CD, Grafana
+- **Team:** Eight platform engineers supporting 70 product engineers
+- **Salary:** EUR 105,000-130,000 plus stock options
+- **Work model:** Remote-first with quarterly Berlin planning sessions
+- **Interview:** Architecture case, technical deep dive, and cross-functional panel
+
+## Fit Hypothesis
+
+Strong platform and reliability fit with a manageable GPU-domain gap. Quarterly travel and country eligibility remain conditional.
+
+## Quality Signals
+
+- quality_badge: `quality_green`
+- quality_audit_recommendation: `proceed_with_questions`
+- compensation_signal: `transparent_aligned`
+
+## Open Questions
+
+- Are quarterly Berlin sessions mandatory for remote employees?
+- Is deep production GPU scheduling experience a day-one requirement?

--- a/fixtures/demo-04-atlas-devex-lead.md
+++ b/fixtures/demo-04-atlas-devex-lead.md
@@ -1,0 +1,41 @@
+---
+source_id: demo-004
+source_url: https://example.com/careers/developer-experience-lead
+captured_at: 2026-08-14
+company: Atlas Foundry
+role_title: Developer Experience Lead
+location: Remote (Europe)
+work_model: remote
+source_class: company_careers_page
+capture_method: manual_snapshot
+triage_state: triaged_apply
+initial_fit_score_value: 4.5
+---
+
+## Why Captured
+
+The role owns internal developer workflows, AI-assisted delivery standards, and measurable improvements to engineering feedback loops.
+
+## Extracted Facts
+
+- **Scope:** CI performance, service templates, coding assistants, and engineering metrics
+- **Stack:** TypeScript, Python, Backstage, GitHub Actions, Kubernetes
+- **Team:** Player-coach role with no direct reports in the first year
+- **Salary:** EUR 98,000-122,000 plus annual bonus
+- **Work model:** Fully remote with flexible core overlap
+- **Interview:** Written case study, platform design, and stakeholder conversation
+
+## Fit Hypothesis
+
+Direct alignment with developer productivity and governed AI workflow positioning. Evidence for cross-team influence should be emphasized in the application.
+
+## Quality Signals
+
+- quality_badge: `quality_green`
+- quality_audit_recommendation: `proceed`
+- compensation_signal: `transparent_aligned`
+
+## Open Questions
+
+- What baseline engineering metrics already exist?
+- Does player-coach imply future line-management responsibility?

--- a/fixtures/demo-05-quartz-platform-applied.md
+++ b/fixtures/demo-05-quartz-platform-applied.md
@@ -1,0 +1,42 @@
+---
+source_id: demo-005
+source_url: https://example.com/careers/principal-platform-engineer
+captured_at: 2026-08-11
+company: Quartz Relay
+role_title: Principal Platform Engineer
+location: Remote (CET +/- 3 hours)
+work_model: remote
+source_class: company_careers_page
+capture_method: browser_snapshot
+triage_state: applied
+application_status: submitted
+initial_fit_score_value: 4.2
+---
+
+## Why Captured
+
+The platform group is replacing fragmented deployment tooling with a cohesive self-service engineering platform.
+
+## Extracted Facts
+
+- **Scope:** Platform architecture, paved roads, observability, and migration strategy
+- **Stack:** Go, Kubernetes, Terraform, Crossplane, Argo CD, Datadog
+- **Scale:** 140 engineers and 320 production services
+- **Salary:** EUR 100,000-125,000
+- **On-call:** Escalation-only support during local daytime
+- **Application:** Submitted with tailored CV and architecture portfolio
+
+## Fit Hypothesis
+
+Strong platform ownership match. Crossplane depth is limited but not listed as a strict requirement.
+
+## Quality Signals
+
+- quality_badge: `quality_green`
+- quality_audit_recommendation: `proceed`
+- compensation_signal: `transparent_aligned`
+
+## Open Questions
+
+- How much hands-on coding remains at principal level?
+- Which migration outcomes define the first six months?

--- a/fixtures/demo-06-cedar-sre-interview.md
+++ b/fixtures/demo-06-cedar-sre-interview.md
@@ -1,0 +1,42 @@
+---
+source_id: demo-006
+source_url: https://example.com/careers/senior-sre-developer-platform
+captured_at: 2026-08-08
+company: Cedar Robotics
+role_title: Senior SRE - Developer Platform
+location: Remote (Europe)
+work_model: remote
+source_class: company_careers_page
+capture_method: browser_snapshot
+triage_state: interview
+application_status: technical_interview
+initial_fit_score_value: 3.9
+---
+
+## Why Captured
+
+The role applies reliability engineering to build and deployment systems used by robotics software teams.
+
+## Extracted Facts
+
+- **Scope:** Build reliability, deployment safety, incident learning, and observability
+- **Stack:** Linux, Kubernetes, Bazel, Python, Prometheus, Grafana
+- **Scale:** 90 engineers shipping to cloud and edge environments
+- **Salary:** EUR 88,000-108,000
+- **On-call:** Shared daytime support with documented escalation
+- **Interview stage:** Systems design conversation scheduled
+
+## Fit Hypothesis
+
+Strong reliability foundation and useful developer-platform angle. Bazel and robotics-edge deployment are the primary gaps.
+
+## Quality Signals
+
+- quality_badge: `quality_green`
+- quality_audit_recommendation: `proceed`
+- compensation_signal: `transparent_aligned`
+
+## Open Questions
+
+- Does edge support create recurring after-hours incidents?
+- Is the systems design session conversational or live implementation?

--- a/fixtures/demo-07-meridian-offer.md
+++ b/fixtures/demo-07-meridian-offer.md
@@ -1,0 +1,42 @@
+---
+source_id: demo-007
+source_url: https://example.com/careers/fullstack-ai-platform-engineer
+captured_at: 2026-08-04
+company: Meridian Works
+role_title: Fullstack AI Platform Engineer
+location: Remote (Europe)
+work_model: remote
+source_class: company_careers_page
+capture_method: manual_snapshot
+triage_state: offer
+application_status: offer_received
+initial_fit_score_value: 4.3
+---
+
+## Why Captured
+
+The role spans Python services, workflow orchestration, and a practical operations interface for internal AI products.
+
+## Extracted Facts
+
+- **Scope:** Agent workflow APIs, evaluation services, and operator-facing React tools
+- **Stack:** Python, FastAPI, React, PostgreSQL, Temporal, OpenTelemetry
+- **Team:** Product squad of seven with dedicated design and data partners
+- **Salary:** EUR 96,000 base plus equity and learning budget
+- **Work model:** Remote with four overlap hours
+- **Current state:** Written offer received; benefits and equity review pending
+
+## Fit Hypothesis
+
+Excellent full-stack AI product fit with a balanced backend and interface scope. Final decision depends on total compensation and role boundaries.
+
+## Quality Signals
+
+- quality_badge: `quality_green`
+- quality_audit_recommendation: `proceed`
+- compensation_signal: `transparent_aligned`
+
+## Open Questions
+
+- What is the equity exercise window?
+- How is ownership divided between workflow infrastructure and product UI?

--- a/fixtures/demo-08-meadow-devops-reject.md
+++ b/fixtures/demo-08-meadow-devops-reject.md
@@ -1,0 +1,40 @@
+---
+source_id: demo-008
+source_url: https://example.com/careers/senior-devops-engineer
+captured_at: 2026-08-02
+company: Meadow Analytics
+role_title: Senior DevOps Engineer
+location: London hybrid
+work_model: hybrid
+source_class: company_careers_page
+capture_method: manual_snapshot
+triage_state: triaged_reject
+initial_fit_score_value: 2.7
+---
+
+## Why Captured
+
+The technical stack initially looked relevant, but the operating model conflicts with sustainable work and location requirements.
+
+## Extracted Facts
+
+- **Scope:** AWS infrastructure, CI/CD, security tooling, and production support
+- **Stack:** Terraform, EKS, GitHub Actions, Python, PagerDuty
+- **Work model:** Three mandatory London office days each week
+- **On-call:** One week in four with overnight primary response
+- **Salary:** GBP 75,000-90,000
+- **Interview:** Recruiter screen followed by live coding and whiteboard exercise
+
+## Fit Hypothesis
+
+Technical overlap is outweighed by mandatory relocation, frequent office attendance, overnight on-call, and an unsuitable interview format.
+
+## Quality Signals
+
+- quality_badge: `quality_amber`
+- quality_audit_recommendation: `reject`
+- compensation_signal: `transparent_below_target`
+
+## Open Questions
+
+- None. Structural constraints are sufficient for rejection.

--- a/fixtures/demo-09-ember-ai-platform.md
+++ b/fixtures/demo-09-ember-ai-platform.md
@@ -1,0 +1,42 @@
+---
+source_id: demo-009
+source_url: https://example.com/careers/platform-engineer-agent-runtime
+captured_at: 2026-08-01
+company: Ember Grid
+role_title: Platform Engineer - Agent Runtime
+location: Remote (EMEA)
+work_model: remote
+source_class: company_careers_page
+capture_method: browser_snapshot
+triage_state: applied
+application_status: recruiter_review
+initial_fit_score_value: 4.0
+---
+
+## Why Captured
+
+The role combines agent execution infrastructure, observability, and secure developer self-service in a small product organization.
+
+## Extracted Facts
+
+- **Scope:** Sandboxed agent execution, policy controls, telemetry, and release automation
+- **Stack:** Python, Go, Kubernetes, PostgreSQL, NATS, OpenTelemetry
+- **Scale:** 12,000 isolated workflow runs per day
+- **Salary:** EUR 90,000-112,000 plus equity
+- **Work model:** Remote across EMEA, asynchronous by default
+- **Application:** Recruiter review in progress
+
+## Fit Hypothesis
+
+Strong agent-runtime and platform overlap. Go depth is developing, but Python and reliability ownership provide credible adjacent evidence.
+
+## Quality Signals
+
+- quality_badge: `quality_green`
+- quality_audit_recommendation: `proceed`
+- compensation_signal: `transparent_aligned`
+
+## Open Questions
+
+- What percentage of the runtime is implemented in Go?
+- Are security reviews owned by this role or a dedicated security team?

--- a/fixtures/sample-form-fields.yaml
+++ b/fixtures/sample-form-fields.yaml
@@ -1,0 +1,13 @@
+fields:
+  - id: motivation
+    heading: Why are you interested in this role?
+    required: true
+    max_length: 1000
+  - id: infrastructure_example
+    heading: Describe a complex infrastructure challenge you solved.
+    required: true
+    max_length: 1500
+  - id: gpu_experience
+    heading: What experience do you have with GPU infrastructure? (optional)
+    required: false
+    max_length: 800

--- a/fixtures/sample-job-posting.md
+++ b/fixtures/sample-job-posting.md
@@ -8,6 +8,11 @@ location: Remote (Europe)
 work_model: remote
 source_class: company_careers_page
 capture_method: playwright_snapshot
+triage_state: captured
+hiring_region: europe
+sponsorship_required: false
+sponsorship_provided: false
+relocation_required: false
 ---
 
 ## Why Captured

--- a/fixtures/sample-target_roles.md
+++ b/fixtures/sample-target_roles.md
@@ -1,0 +1,27 @@
+# Career Direction
+
+## Target roles
+
+- AI-enabled platform engineering
+- Developer productivity and internal tooling
+- Infrastructure automation with practical LLM integration
+
+## Decision criteria
+
+### Must have
+
+- Remote-first or flexible hybrid work
+- Clear ownership and sustainable delivery expectations
+- No recurring overnight on-call
+
+### Prefer
+
+- Small, experienced engineering teams
+- Visible product impact and room to improve developer workflows
+- Compensation and progression discussed early
+
+### Avoid
+
+- Permanent high-frequency incident rotation
+- Roles centered on model research or training
+- Unclear location, work authorization, or travel expectations

--- a/modes/05_DOCUMENT_OUTPUT.md
+++ b/modes/05_DOCUMENT_OUTPUT.md
@@ -110,7 +110,9 @@ validated through multiple export cycles.
 - Avoid complex tables unless the user asks for a human-designed, non-ATS document.
 - Verify LibreOffice rendering before final delivery when a DOCX is generated.
 - **DOCX MUST be generated via `pandoc` with the reference template:**
-  `pandoc <input>.md --reference-doc=exports/cv-variants-2026-06-21/cv-reference.docx -o <output>.docx`
+  `pandoc <input>.md --reference-doc=exports/cv-reference.docx -o <output>.docx`
+  The template is user-supplied and must be licensed for the user's intended
+  use; Community Edition does not bundle a personal style template.
   Direct `python-docx` generation is acceptable only for non-CV documents.
 
 ## Output Rule

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ Sponsor = "https://github.com/sponsors/rcnsnr"
 [tool.setuptools]
 packages = ["jsw", "dashboard"]
 package-dir = { jsw = "scripts/jsw", dashboard = "dashboard" }
+license-files = ["LICENSE", "NOTICE", "COMMERCIAL_USE.md"]
 
 [tool.setuptools.package-data]
 dashboard = ["templates/*.html", "static/*.css", "static/*.js", "static/*.svg"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 dependencies = [
     "pyyaml>=6.0,<7.0",
     "markdown>=3.5,<4.0",
+    "bleach>=6.4,<7.0",
 ]
 
 [project.optional-dependencies]
@@ -42,6 +43,8 @@ export = [
 ]
 dev = [
     "pytest>=7.0.0",
+    "httpx>=0.27,<1.0",
+    "httpx2>=2.0,<3.0",
 ]
 
 [project.scripts]
@@ -54,8 +57,8 @@ Issues = "https://github.com/rcnsnr/job-search-workflow/issues"
 Sponsor = "https://github.com/sponsors/rcnsnr"
 
 [tool.setuptools]
-packages = ["jsw"]
-package-dir = { "" = "scripts" }
+packages = ["jsw", "dashboard"]
+package-dir = { jsw = "scripts/jsw", dashboard = "dashboard" }
 
 [tool.setuptools.package-data]
-jsw = ["*.py"]
+dashboard = ["templates/*.html", "static/*.css", "static/*.js", "static/*.svg"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pytest>=7.0.0",
     "httpx>=0.27,<1.0",
     "httpx2>=2.0,<3.0",
+    "ruff==0.14.10",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,10 +7,13 @@ pypandoc>=1.11
 
 # Testing
 pytest>=7.0.0
+httpx>=0.27,<1.0
+httpx2>=2.0,<3.0
 
 # Optional: Dashboard
 fastapi>=0.110,<1.0
 uvicorn[standard]>=0.27,<1.0
 jinja2>=3.1,<4.0
 markdown>=3.5,<4.0
+bleach>=6.4,<7.0
 pyyaml>=6.0,<7.0

--- a/scripts/check_license_policy.py
+++ b/scripts/check_license_policy.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Fail closed when first-party license and commercial boundaries drift."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+POLYFORM_LICENSE_ID = "PolyForm-Noncommercial-1.0.0"
+OFFICIAL_LICENSE_SHA256 = "ffcca38841adb694b6f380647e15f17c446a4d1656fed51a1e2041d064c94cc8"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def check_canonical_license(root: Path) -> list[str]:
+    errors: list[str] = []
+    license_path = root / "LICENSE"
+    if not license_path.is_file():
+        return ["LICENSE is missing; the official PolyForm text is required"]
+
+    digest = hashlib.sha256(license_path.read_bytes()).hexdigest()
+    if digest != OFFICIAL_LICENSE_SHA256:
+        errors.append("LICENSE is not byte-identical to the official PolyForm Noncommercial 1.0.0 text")
+
+    notice_path = root / "NOTICE"
+    if not notice_path.is_file():
+        errors.append("NOTICE is missing")
+    else:
+        notice = read_text(notice_path)
+        if "Required Notice: Copyright 2026 Orcun Sener" not in notice:
+            errors.append("NOTICE is missing the required copyright notice")
+        if POLYFORM_LICENSE_ID not in notice:
+            errors.append("NOTICE is missing the PolyForm SPDX identifier")
+    return errors
+
+
+def check_extension_metadata(root: Path) -> list[str]:
+    errors: list[str] = []
+    extension = root / "tools" / "browser-extension"
+    package_path = extension / "package.json"
+    if not package_path.is_file():
+        errors.append("browser-extension package.json is missing")
+    else:
+        package = json.loads(read_text(package_path))
+        actual = package.get("license")
+        if actual != POLYFORM_LICENSE_ID:
+            errors.append(f"browser-extension package.json license is {actual!r}, not {POLYFORM_LICENSE_ID}")
+
+    lock_path = extension / "package-lock.json"
+    if not lock_path.is_file():
+        errors.append("browser-extension package-lock.json is missing")
+    else:
+        lock = json.loads(read_text(lock_path))
+        actual = lock.get("packages", {}).get("", {}).get("license")
+        if actual != POLYFORM_LICENSE_ID:
+            errors.append(f"browser-extension package-lock root license is {actual!r}, not {POLYFORM_LICENSE_ID}")
+
+    readme_path = extension / "readme.md"
+    if not readme_path.is_file():
+        errors.append("browser-extension readme.md is missing")
+    else:
+        readme = read_text(readme_path)
+        if "MIT License" in readme:
+            errors.append("browser-extension readme.md still claims the MIT License")
+        if "../../LICENSE" not in readme or "../../COMMERCIAL_USE.md" not in readme:
+            errors.append("browser-extension readme.md does not link the root license boundary")
+    return errors
+
+
+def check_policy_documents(root: Path) -> list[str]:
+    errors: list[str] = []
+    required_phrases = {
+        "README.md": ("source-available", "Commercial use is not granted"),
+        "COMMERCIAL_USE.md": ("Owner-Operated SaaS", "separate written agreement"),
+        "CLA.md": ("source-available", "separate commercial license terms"),
+        "CONTRIBUTING.md": ("Contributor License Agreement", "separate commercial licenses"),
+        ".github/pull_request_template.md": (
+            "Contributor and License Confirmation",
+            "maintainer may offer separate commercial licenses",
+        ),
+        "PUBLISH_CHECKLIST_EXTENSION.md": ("LICENSE", "NOTICE", "COMMERCIAL_USE.md"),
+        "pyproject.toml": (
+            "PolyForm Noncommercial 1.0.0",
+            'license-files = ["LICENSE", "NOTICE", "COMMERCIAL_USE.md"]',
+        ),
+    }
+    for relative, phrases in required_phrases.items():
+        path = root / relative
+        if not path.is_file():
+            errors.append(f"{relative} is missing")
+            continue
+        content = read_text(path)
+        for phrase in phrases:
+            if phrase not in content:
+                errors.append(f"{relative} is missing required license phrase: {phrase}")
+
+    cla_path = root / "CLA.md"
+    if cla_path.is_file() and "open-source project" in read_text(cla_path).lower():
+        errors.append("CLA.md incorrectly describes Community Edition as an open-source project")
+    return errors
+
+
+def check_license_policy(root: Path = ROOT) -> list[str]:
+    return [
+        *check_canonical_license(root),
+        *check_extension_metadata(root),
+        *check_policy_documents(root),
+    ]
+
+
+def main() -> int:
+    errors = check_license_policy()
+    if errors:
+        for error in errors:
+            print(f"FAIL license_policy: {error}")
+        return 1
+    print("PASS license_policy: PolyForm noncommercial and commercial SaaS boundaries are aligned")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/job_dashboard.py
+++ b/scripts/job_dashboard.py
@@ -275,7 +275,7 @@ HTML_TEMPLATE = """<!doctype html>
 <head>
   <meta charset=\"utf-8\">
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-  <title>Job Search Workflow Dashboard</title>
+  <title>Job Search Workflow Community Edition</title>
   <style>
     :root {
       color-scheme: light dark;
@@ -539,7 +539,7 @@ HTML_TEMPLATE = """<!doctype html>
 <body>
   <main>
     <header id=\"top\">
-      <h1>Job Search Workflow Dashboard</h1>
+      <h1>Job Search Workflow Community Edition</h1>
       <p>Read-only local dashboard. Canonical truth still lives in <code>inbox/jobs/*.md</code>.</p>
     </header>
 
@@ -1231,7 +1231,7 @@ class DashboardHandler(BaseHTTPRequestHandler):
 
 def serve(host: str, port: int) -> int:
     server = ThreadingHTTPServer((host, port), DashboardHandler)
-    print(f"Job Search Workflow dashboard running at http://{host}:{port}")
+    print(f"Job Search Workflow Community Edition running at http://{host}:{port}")
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/scripts/jsw/__main__.py
+++ b/scripts/jsw/__main__.py
@@ -16,7 +16,14 @@ import sys
 DEFAULT_USER_FILES = {
     "career_profile.md": "# Career Profile\n\nReplace this text with verified career information.\n",
     "skill_matrix_summary.md": "# Skill Matrix Summary\n\nList verified skills and evidence here.\n",
-    "target_roles.md": "# Target Roles\n\nDefine target roles, locations, and constraints here.\n",
+    "target_roles.md": (
+        "# Career Direction\n\n"
+        "## Target roles\n\n- Add the roles you want to pursue.\n\n"
+        "## Decision criteria\n\n"
+        "### Must have\n\n- Add non-negotiable requirements.\n\n"
+        "### Prefer\n\n- Add positive signals and trade-offs.\n\n"
+        "### Avoid\n\n- Add boundaries that should stop an application.\n"
+    ),
 }
 
 

--- a/scripts/jsw/__main__.py
+++ b/scripts/jsw/__main__.py
@@ -9,7 +9,15 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import sys
+
+
+DEFAULT_USER_FILES = {
+    "career_profile.md": "# Career Profile\n\nReplace this text with verified career information.\n",
+    "skill_matrix_summary.md": "# Skill Matrix Summary\n\nList verified skills and evidence here.\n",
+    "target_roles.md": "# Target Roles\n\nDefine target roles, locations, and constraints here.\n",
+}
 
 
 def main():
@@ -39,7 +47,7 @@ def run_dashboard():
         print("uvicorn not installed. Run: pip install uvicorn[standard]")
         sys.exit(1)
 
-    print("Starting Job Search Workflow Dashboard on http://localhost:3000")
+    print("Starting Job Search Workflow Community Edition on http://localhost:3000")
     print("Press Ctrl+C to stop.")
     uvicorn.run(
         "dashboard.server:app",
@@ -54,7 +62,7 @@ def run_init():
     """Interactive init wizard — create user_data skeleton."""
     from pathlib import Path
 
-    root = Path(__file__).resolve().parents[2]
+    root = Path(os.environ.get("JSW_WORKSPACE", Path.cwd())).expanduser().resolve()
     user_data = root / "user_data"
     skeleton = root / "templates" / "user-data-skeleton"
 
@@ -68,15 +76,17 @@ def run_init():
     user_data.mkdir(exist_ok=True)
 
     skeleton_dir = skeleton if skeleton.exists() else root / "templates" / "user_data"
-    if not skeleton_dir.exists():
-        print(f"Error: skeleton directory not found at {skeleton_dir}")
-        sys.exit(1)
+    source_files = (
+        {path.name: path.read_text(encoding="utf-8") for path in skeleton_dir.glob("*.md")}
+        if skeleton_dir.exists()
+        else DEFAULT_USER_FILES
+    )
 
-    for path in skeleton_dir.glob("*.md"):
-        dest = user_data / path.name
+    for filename, content in source_files.items():
+        dest = user_data / filename
         if not dest.exists():
-            dest.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
-            print(f"  Created: user_data/{path.name}")
+            dest.write_text(content, encoding="utf-8")
+            print(f"  Created: user_data/{filename}")
 
     print(f"\nInit complete. Edit files in {user_data} to add your data.")
     print("Then run: python3 -m jsw dashboard")

--- a/scripts/linkedin_capture_server.py
+++ b/scripts/linkedin_capture_server.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import yaml
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from pydantic import BaseModel, Field
 from starlette.responses import JSONResponse
 
@@ -129,7 +129,7 @@ def find_existing_capture(inbox_dir: str, source_url: str) -> str | None:
 
 def create_app(inbox_dir: str | None = None) -> FastAPI:
     """Create the FastAPI app with an optional inbox directory override."""
-    inbox_dir = inbox_dir or os.environ.get("CAREEROPS_INBOX_DIR") or DEFAULT_INBOX_DIR
+    inbox_dir = inbox_dir or os.environ.get("JSW_INBOX_DIR") or DEFAULT_INBOX_DIR
     inbox_path = os.path.abspath(inbox_dir)
     os.makedirs(inbox_path, exist_ok=True)
 
@@ -211,7 +211,7 @@ def create_app(inbox_dir: str | None = None) -> FastAPI:
 def main() -> None:
     import uvicorn
 
-    port = int(os.environ.get("CAREEROPS_CAPTURE_PORT") or os.environ.get("CAREEROPS_LINKEDIN_CAPTURE_PORT", "8766"))
+    port = int(os.environ.get("JSW_CAPTURE_PORT", "8766"))
     app = create_app()
     uvicorn.run(app, host="127.0.0.1", port=port, log_level="info")
 

--- a/scripts/md_to_tex.py
+++ b/scripts/md_to_tex.py
@@ -216,20 +216,13 @@ def convert(md_path: Path) -> str:
     # For experience entries: track pending job title + meta line
     pending_title = None
 
-    def close_itemize():
-        nonlocal in_itemize
-        if in_itemize:
-            tex_add("\\end{itemize}\n")
-            in_itemize = False
-
     # We'll build tex via a list for efficiency
     out_parts = [tex]
 
     def add(s):
         out_parts.append(s)
 
-    # redefine close_itemize to use out_parts
-    def close_itemize2():
+    def close_itemize():
         nonlocal in_itemize
         if in_itemize:
             add("\\end{itemize}\n\n")
@@ -242,7 +235,7 @@ def convert(md_path: Path) -> str:
 
         # H2 section
         if stripped.startswith("## "):
-            close_itemize2()
+            close_itemize()
             pending_title = None
             sec = stripped[3:].strip()
             current_section = sec
@@ -252,7 +245,7 @@ def convert(md_path: Path) -> str:
 
         # H3 subsection
         if stripped.startswith("### "):
-            close_itemize2()
+            close_itemize()
             sub = stripped[4:].strip()
             if current_section == "Professional Experience":
                 # job entry: title now, next non-empty non-# line is meta
@@ -311,16 +304,16 @@ def convert(md_path: Path) -> str:
                 i += 1
                 continue
             # otherwise: paragraph text (summary, project description, training line)
-            close_itemize2()
+            close_itemize()
             add(convert_inline(stripped) + "\n\n")
             i += 1
             continue
 
         # empty line
-        close_itemize2()
+        close_itemize()
         i += 1
 
-    close_itemize2()
+    close_itemize()
     out_parts.append(POSTAMBLE)
     return "".join(out_parts)
 
@@ -330,7 +323,6 @@ def find_legacy_cvs_missing_tex(glob: str = "*-cv-*.md") -> list[Path]:
     apps = REPO_ROOT / "exports" / "applications"
     result = []
     for md in apps.rglob(glob):
-        stem = md.stem  # e.g. myname-cv-polar-senior-platform-engineer
         tex = md.with_suffix(".tex")
         pdf = md.with_suffix(".pdf")
         if pdf.exists() and not tex.exists():

--- a/scripts/relocation_livability_research.py
+++ b/scripts/relocation_livability_research.py
@@ -15,10 +15,6 @@ Usage:
 
 import argparse
 import json
-import re
-import sys
-import urllib.request
-import urllib.parse
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -123,9 +119,6 @@ def generate_report(
     If scores and notes are provided, use them. Otherwise, output a template
     with Unknown for manual filling.
     """
-    city_slug = city.lower().replace(" ", "-")
-    country_slug = country.lower().replace(" ", "-")
-
     if scores is None:
         scores = {k: None for k in DIMENSIONS}
     if notes is None:
@@ -170,8 +163,8 @@ def generate_report(
         "",
         f"**Family profile:** {FAMILY_PROFILE}",
         f"**Salary context:** £{salary_gbp:,.0f}/year" if salary_gbp else "**Salary context:** Unknown",
-        f"**Last updated:** 2026-07-15",
-        f"**Data freshness:** refresh every 6 months or when new city added",
+        "**Last updated:** 2026-07-15",
+        "**Data freshness:** refresh every 6 months or when new city added",
         "",
         "## Scoring",
         "",

--- a/scripts/scan_for_clones.py
+++ b/scripts/scan_for_clones.py
@@ -65,7 +65,6 @@ def main():
     parser.add_argument("--output", type=str, default="", help="Output report file path")
     args = parser.parse_args()
 
-    import urllib.parse  # needed for quote
 
     print("Scanning GitHub for potential clones of job-search-workflow...\n")
 
@@ -109,7 +108,7 @@ def main():
     report_lines = [
         f"# Clone Scan Report — {today}",
         "",
-        f"## Summary",
+        "## Summary",
         "",
         f"- Queries run: {len(SEARCH_QUERIES)}",
         f"- Potential clones found: {len(potential_clones)}",
@@ -132,10 +131,10 @@ def main():
         for clone in potential_clones:
             report_lines.append(f"- **{clone['repo']}** — {clone['url']}")
             report_lines.append(f"  Matched: `{clone['query'][:60]}`")
-            report_lines.append(f"  Action: Review manually. If clone, consider:")
-            report_lines.append(f"    - DMCA takedown notice to GitHub")
-            report_lines.append(f"    - Contact author for license compliance")
-            report_lines.append(f"    - Public community call-out if ignored")
+            report_lines.append("  Action: Review manually. If clone, consider:")
+            report_lines.append("    - DMCA takedown notice to GitHub")
+            report_lines.append("    - Contact author for license compliance")
+            report_lines.append("    - Public community call-out if ignored")
             report_lines.append("")
 
     report_content = "\n".join(report_lines) + "\n"

--- a/scripts/scan_pii.py
+++ b/scripts/scan_pii.py
@@ -1,136 +1,165 @@
 #!/usr/bin/env python3
-"""Fail-closed PII and private-reference scanner for the public surface.
+"""Scan an explicit public tree for personal data and private references."""
 
-Scans public/tools/browser-extension/ and public/scripts/ for known hard-PII
-and owner-specific patterns. Designed to be run in CI before any public release.
+from __future__ import annotations
 
-Known non-PII patterns such as generic localhost references, the Job Search Workflow
-framework name, and public LinkedIn URLs are allow-listed.
-"""
-
+import argparse
 import os
 import re
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 
-# File extensions to scan
-EXTENSIONS = {".js", ".json", ".md", ".html", ".py", ".css"}
 
-# Files and directories that are third-party or scanner artifacts and must be skipped.
-SKIP_NAMES = {
-    "node_modules",
+ROOT = Path(__file__).resolve().parents[1]
+SCANNER_PATH = Path(__file__).resolve()
+
+TEXT_EXTENSIONS = {
+    ".bat",
+    ".css",
+    ".html",
+    ".js",
+    ".json",
+    ".md",
+    ".py",
+    ".sh",
+    ".svg",
+    ".tex",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+TEXT_FILENAMES = {"CLA", "CODE_OF_CONDUCT", "CONTRIBUTING", "LICENSE"}
+SKIP_DIRECTORIES = {
     ".git",
-    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
     ".venv",
-    "package-lock.json",
+    "__pycache__",
+    "coverage",
+    "dist",
+    "htmlcov",
+    "node_modules",
+    "reports",
+    "venv",
+}
+SKIP_FILES = {
     "cv-reference.docx",
+    "job-search-workflow-capture-v2.0.0.zip",
+    "package-lock.json",
 }
 
-# Patterns that are considered hard PII or private references.
-# Each tuple: (pattern, description)
-DENIED_PATTERNS = [
-    # Email addresses (but not example/placeholder domains)
-    (
-        r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(?:com|net|org|io|co|me|tr|eu|gmail|yahoo|outlook|hotmail)",
-        "email address",
-    ),
-    # Home directory paths that include the owner's username
-    (r"/home/orcun/", "owner home directory path"),
-    # Owner username / placeholder usernames that should not be public
-    (r"\borcun\b", "owner username"),
-    (r"\bkullaniciadi\b", "placeholder username in Turkish"),
-    # Old private repo slug that should not appear in public
-    (r"linkedin-job-filter", "old private repo slug"),
-    # Old Turkish status fallback that signals untranslated private UI
-    (r"\bBelirsiz\b", "untranslated Turkish fallback 'Belirsiz'"),
-    # Owner-specific locations that should not be hard-coded
-    (r"\bIstanbul\b", "owner city"),
-    (r"\bTurkey\b", "owner country"),
-    (r"\bAnkara\b", "owner-specific city"),
-]
-
-# Patterns that are allowed even if they look like a denied match.
-ALLOWED_PATTERNS = [
-    # Generic localhost capture server reference
-    (r"localhost:\d+", "localhost capture server"),
-    # Public LinkedIn URL patterns
-    (r"https?://(www\.)?linkedin\.com", "public LinkedIn URL"),
-    # Job Search Workflow framework name is public
-    (r"Job Search Workflow", "Job Search Workflow framework name"),
-    # Job Search Workflow Capture public name
-    (r"Job Search Workflow Capture", "public product name"),
-    # job-search-workflow-capture slug
-    (r"job-search-workflow-capture", "public repo slug"),
-    # Generic placeholder username
-    (r"<your-username>", "placeholder username"),
-    # Example / placeholder domains
-    (r"@example\.", "example domain"),
-    (r"example\.com", "example domain"),
-]
+EMAIL_PATTERN = re.compile(
+    r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+    re.IGNORECASE,
+)
+ALLOWED_EMAIL_PATTERNS = (
+    re.compile(r"^[^@]+@example\.(?:com|net|org)$", re.IGNORECASE),
+    re.compile(r"^[^@]+@users\.noreply\.github\.com$", re.IGNORECASE),
+)
+DENIED_PATTERNS = (
+    (re.compile(r"career" r"ops", re.IGNORECASE), "retired private product name"),
+    (re.compile(r"/home/orcun/", re.IGNORECASE), "owner home directory path"),
+    (re.compile(r"\bkullaniciadi\b", re.IGNORECASE), "Turkish placeholder username"),
+    (re.compile(r"linkedin-job-filter", re.IGNORECASE), "old private repository slug"),
+    (re.compile(r"\bBelirsiz\b", re.IGNORECASE), "untranslated Turkish fallback"),
+    (re.compile(r"\bIstanbul\b", re.IGNORECASE), "owner-specific city"),
+    (re.compile(r"\bTurkey\b", re.IGNORECASE), "owner-specific country"),
+    (re.compile(r"\bAnkara\b", re.IGNORECASE), "owner-specific city"),
+)
 
 
-def should_skip(path: str) -> bool:
-    for part in path.split(os.sep):
-        if part in SKIP_NAMES:
-            return True
-    return False
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line_number: int
+    description: str
+    line: str
 
 
-def is_allowed(line: str) -> bool:
-    for pattern, _ in ALLOWED_PATTERNS:
-        if re.search(pattern, line, re.IGNORECASE):
-            return True
-    return False
+def is_allowed_email(value: str) -> bool:
+    return any(pattern.fullmatch(value) for pattern in ALLOWED_EMAIL_PATTERNS)
 
 
-def scan_file(path: str) -> list[tuple[int, str, str]]:
-    findings = []
-    with open(path, encoding="utf-8") as file:
-        for line_number, line in enumerate(file, start=1):
-            if is_allowed(line):
-                continue
-            for pattern, description in DENIED_PATTERNS:
-                if re.search(pattern, line, re.IGNORECASE):
-                    findings.append((line_number, description, line.strip()))
-                    break
+def should_scan(path: Path) -> bool:
+    if path.resolve() == SCANNER_PATH:
+        return False
+    if path.name in SKIP_FILES:
+        return False
+    return path.name in TEXT_FILENAMES or path.suffix.lower() in TEXT_EXTENSIONS
+
+
+def scan_line(line: str) -> list[str]:
+    descriptions: list[str] = []
+    if any(not is_allowed_email(match.group(0)) for match in EMAIL_PATTERN.finditer(line)):
+        descriptions.append("email address")
+    for pattern, description in DENIED_PATTERNS:
+        if pattern.search(line):
+            descriptions.append(description)
+    return descriptions
+
+
+def iter_files(scan_root: Path):
+    if scan_root.is_file():
+        if should_scan(scan_root):
+            yield scan_root
+        return
+
+    for current_root, directories, filenames in os.walk(scan_root):
+        directories[:] = sorted(name for name in directories if name not in SKIP_DIRECTORIES)
+        root_path = Path(current_root)
+        for filename in sorted(filenames):
+            path = root_path / filename
+            if should_scan(path):
+                yield path
+
+
+def scan_path(path: str | Path) -> list[Finding]:
+    scan_root = Path(path).expanduser().resolve()
+    if not scan_root.exists():
+        raise FileNotFoundError(f"Scan path does not exist: {scan_root}")
+
+    findings: list[Finding] = []
+    for file_path in iter_files(scan_root):
+        relative_path = file_path.name if scan_root.is_file() else file_path.relative_to(scan_root).as_posix()
+        lines = file_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        for line_number, line in enumerate(lines, start=1):
+            for description in scan_line(line):
+                findings.append(Finding(relative_path, line_number, description, line.strip()))
     return findings
 
 
-def main() -> int:
-    base_dir = os.path.dirname(__file__)
-    repo_dir = os.path.abspath(os.path.join(base_dir, ".."))
-    scan_dirs = [
-        os.path.join(repo_dir, "tools", "browser-extension"),
-        os.path.join(repo_dir, "scripts"),
-    ]
-    scanner_path = os.path.abspath(__file__)
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=ROOT,
+        help="File or directory to scan (default: repository root).",
+    )
+    return parser.parse_args(argv)
 
-    all_findings: list[tuple[str, int, str, str]] = []
 
-    for scan_dir in scan_dirs:
-        if not os.path.isdir(scan_dir):
-            continue
-        for root, _, files in os.walk(scan_dir):
-            for filename in files:
-                full_path = os.path.join(root, filename)
-                if os.path.abspath(full_path) == scanner_path:
-                    # Do not scan the scanner itself for its own regex strings.
-                    continue
-                if should_skip(full_path):
-                    continue
-                ext = os.path.splitext(filename)[1].lower()
-                if ext not in EXTENSIONS:
-                    continue
-                filepath = os.path.relpath(full_path, repo_dir)
-                for line_number, description, line in scan_file(full_path):
-                    all_findings.append((filepath, line_number, description, line))
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        findings = scan_path(args.path)
+    except (FileNotFoundError, OSError) as error:
+        print(f"FAIL PII scan: {error}", file=sys.stderr)
+        return 2
 
-    if all_findings:
-        print("❌ PII / private-reference scan found potential issues:", file=sys.stderr)
-        for filepath, line_number, description, line in all_findings:
-            print(f"  {filepath}:{line_number}: {description}: {line}", file=sys.stderr)
+    if findings:
+        print("FAIL PII / private-reference scan found potential issues:", file=sys.stderr)
+        for finding in findings:
+            print(
+                f"  {finding.path}:{finding.line_number}: {finding.description}: {finding.line}",
+                file=sys.stderr,
+            )
         return 1
 
-    print("✅ PII / private-reference scan passed. No hard PII or owner-specific patterns found.")
+    print("PASS PII / private-reference scan")
     return 0
 
 

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -81,8 +81,8 @@ if errorlevel 1 goto fail
 if not exist exports mkdir exports
 if errorlevel 1 goto fail
 
-if exist fixtures\sample-career_profile.md if not exist user_data\career_profile.md (
-    copy fixtures\sample-career_profile.md user_data\career_profile.md >nul
+if exist fixtures\sample-profile.md if not exist user_data\career_profile.md (
+    copy fixtures\sample-profile.md user_data\career_profile.md >nul
     if errorlevel 1 goto fail
     echo Copied sample profile: user_data\career_profile.md
 )

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -13,7 +13,7 @@ if "%~1"=="-h" goto help
 if not "%~2"=="" goto invalid_args
 if not "%~1"=="" if not "%~1"=="--check-only" goto invalid_args
 
-echo Starting the Job Search Workflow Public Framework setup check...
+echo Starting the Job Search Workflow Community Edition setup check...
 echo Repository root: %CD%
 
 if not exist README.md (
@@ -53,8 +53,13 @@ echo Python version OK: !PY_MAJOR!.!PY_MINOR!
 for /f "tokens=*" %%a in ('node --version') do set "NODE_VERSION=%%a"
 set "NODE_VERSION=!NODE_VERSION:v=!"
 for /f "tokens=1 delims=." %%a in ("!NODE_VERSION!") do set "NODE_MAJOR=%%a"
-if !NODE_MAJOR! LSS 18 (
-    echo Node.js 18 or newer is required. Found: !NODE_VERSION! >&2
+for /f "tokens=2 delims=." %%a in ("!NODE_VERSION!") do set "NODE_MINOR=%%a"
+if !NODE_MAJOR! LSS 22 (
+    echo Node.js 22.12 or newer is required. Found: !NODE_VERSION! >&2
+    goto fail
+)
+if !NODE_MAJOR! EQU 22 if !NODE_MINOR! LSS 12 (
+    echo Node.js 22.12 or newer is required. Found: !NODE_VERSION! >&2
     goto fail
 )
 echo Node.js version OK: !NODE_VERSION!

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -116,8 +116,8 @@ for dir in user_data inbox/jobs runs outputs exports; do
 done
 
 if [[ -d "$REPO_ROOT/fixtures" ]]; then
-    if [[ ! -f "$REPO_ROOT/user_data/career_profile.md" && -f "$REPO_ROOT/fixtures/sample-career_profile.md" ]]; then
-        cp "$REPO_ROOT/fixtures/sample-career_profile.md" "$REPO_ROOT/user_data/career_profile.md"
+    if [[ ! -f "$REPO_ROOT/user_data/career_profile.md" && -f "$REPO_ROOT/fixtures/sample-profile.md" ]]; then
+        cp "$REPO_ROOT/fixtures/sample-profile.md" "$REPO_ROOT/user_data/career_profile.md"
         echo "Copied sample profile: user_data/career_profile.md"
     fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Job Search Workflow Public Framework - scripts/setup.sh
+# Job Search Workflow Community Edition - scripts/setup.sh
 # Usage: ./scripts/setup.sh [--check-only]
 #
 # Checks prerequisites, creates missing local directories and sample fixtures,
@@ -43,7 +43,7 @@ MISSING_OPTIONAL=()
 
 cd "$REPO_ROOT"
 
-echo "Starting the Job Search Workflow Public Framework setup check..."
+echo "Starting the Job Search Workflow Community Edition setup check..."
 echo "Repository root: $REPO_ROOT"
 
 for file in "${REQUIRED_FILES[@]}"; do
@@ -93,9 +93,10 @@ echo "Python version OK: $PY_MAJOR.$PY_MINOR"
 
 NODE_VERSION=$(node --version | sed 's/^v//')
 NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+NODE_MINOR=$(echo "$NODE_VERSION" | cut -d. -f2)
 
-if [[ "$NODE_MAJOR" -lt 18 ]]; then
-    fail "Node.js >= 18 is required. Found: $NODE_VERSION"
+if [[ "$NODE_MAJOR" -lt 22 || ("$NODE_MAJOR" -eq 22 && "$NODE_MINOR" -lt 12) ]]; then
+    fail "Node.js >= 22.12 is required. Found: $NODE_VERSION"
     exit 1
 fi
 

--- a/scripts/verify_career_pages.py
+++ b/scripts/verify_career_pages.py
@@ -98,9 +98,6 @@ def main():
             continue
 
         status, error = check_url(url, timeout=args.timeout)
-        detected_ats = detect_ats_provider(url)
-        declared_ats = company.get("ats_provider", "unknown")
-
         if status == 200:
             print(f"  OK    {name}: {status}")
             ok_count += 1

--- a/scripts/verify_linked_artifacts.py
+++ b/scripts/verify_linked_artifacts.py
@@ -174,7 +174,7 @@ def main():
     for r in results:
         counts[r["status"]] = counts.get(r["status"], 0) + 1
 
-    print(f"=== GAP-20260719-01 Linked Artifact Verification Check ===")
+    print("=== GAP-20260719-01 Linked Artifact Verification Check ===")
     print(f"Files scanned: {len(results)}")
     print(f"  PASS (verified): {counts['pass']}")
     print(f"  FAIL (missing):  {counts['fail']}")

--- a/scripts/verify_no_turkish.py
+++ b/scripts/verify_no_turkish.py
@@ -270,9 +270,13 @@ def tokenize(text: str) -> list[str]:
     return re.findall(r"[A-Za-z0-9_\-ÇĞİÖŞÜçğıöşü]+", text)
 
 
-def check_line(line: str, path: Path, line_no: int, findings: list[str]) -> None:
-    lower_line = line.lower()
-
+def check_line(
+    line: str,
+    path: Path,
+    line_no: int,
+    findings: list[str],
+    allowed: set[str],
+) -> None:
     # Layer 1: Turkish characters.
     for match in TURKISH_CHARS.finditer(line):
         findings.append(f"{path}:{line_no}:{match.start()+1}: Turkish character '{match.group()}'")
@@ -280,7 +284,7 @@ def check_line(line: str, path: Path, line_no: int, findings: list[str]) -> None
     # Layer 2 & 3: word list and normalized forms.
     for token in tokenize(line):
         lower_token = token.lower()
-        if lower_token in ALLOWED:
+        if lower_token in allowed:
             continue
 
         normalized = lower_token.translate(NORMALIZE_MAP)
@@ -308,7 +312,7 @@ def main() -> int:
             continue
 
         for line_no, line in enumerate(text.splitlines(), start=1):
-            check_line(line, path, line_no, findings)
+            check_line(line, path, line_no, findings, allowed)
 
     if findings:
         print("Turkish content detected:")

--- a/scripts/workflow_guard.py
+++ b/scripts/workflow_guard.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Read-only validation helpers for a local Community Edition workspace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import yaml
+
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+HEADING_RE = re.compile(r"^##\s+(.+?)\s*$")
+EXIT_CODES = {"PASS": 0, "FAIL": 1, "BLOCKED": 2, "REVIEW": 3}
+TRACKING_QUERY_KEYS = {"campaign", "ref", "source", "tracking", "trk"}
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    check: str
+    status: str
+    summary: str
+    details: list[dict[str, Any]] = field(default_factory=list)
+
+
+def load_yaml(path: str | Path) -> dict[str, Any]:
+    value = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected a YAML mapping: {path}")
+    return value
+
+
+def parse_frontmatter(path: str | Path) -> dict[str, Any]:
+    text = Path(path).read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    value = yaml.safe_load(match.group(1))
+    return value if isinstance(value, dict) else {}
+
+
+def normalize_text(value: object) -> str:
+    return " ".join(str(value or "").casefold().split())
+
+
+def normalize_url(value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    parsed = urlsplit(text)
+    normalized_path = parsed.path.rstrip("/") or "/"
+    identity_query = sorted(
+        (key, item)
+        for key, item in parse_qsl(parsed.query, keep_blank_values=True)
+        if not key.casefold().startswith("utm_") and key.casefold() not in TRACKING_QUERY_KEYS
+    )
+    return urlunsplit(
+        (
+            parsed.scheme.casefold(),
+            parsed.netloc.casefold(),
+            normalized_path,
+            urlencode(identity_query),
+            "",
+        )
+    )
+
+
+def iter_job_records(jobs_dir: str | Path):
+    directory = Path(jobs_dir)
+    if not directory.exists():
+        return
+    for path in sorted(directory.glob("*.md")):
+        metadata = parse_frontmatter(path)
+        if metadata:
+            yield path, metadata
+
+
+def check_duplicate(
+    jobs_dir: str | Path,
+    *,
+    company: str,
+    role_title: str,
+    location: str,
+    work_model: str,
+    source_url: str,
+) -> CheckResult:
+    required = {"company": company, "role_title": role_title, "source_url": source_url}
+    missing = [name for name, value in required.items() if not str(value).strip()]
+    if missing:
+        return CheckResult(
+            "duplicate",
+            "BLOCKED",
+            "Candidate identity is incomplete.",
+            [{"reason": "missing_identity", "fields": missing}],
+        )
+
+    candidate_url = normalize_url(source_url)
+    candidate_identity = tuple(normalize_text(value) for value in (company, role_title, location, work_model))
+    details: list[dict[str, Any]] = []
+
+    for path, metadata in iter_job_records(jobs_dir):
+        existing_url = normalize_url(metadata.get("source_url"))
+        if candidate_url and existing_url == candidate_url:
+            details.append({"path": path.name, "reason": "source_url"})
+            continue
+
+        existing_identity = tuple(
+            normalize_text(metadata.get(name))
+            for name in ("company", "role_title", "location", "work_model")
+        )
+        if all(candidate_identity) and existing_identity == candidate_identity:
+            details.append({"path": path.name, "reason": "identity"})
+
+    if details:
+        return CheckResult("duplicate", "FAIL", "A matching job record already exists.", details)
+    return CheckResult("duplicate", "PASS", "No duplicate job record was found.")
+
+
+def parse_answer_sections(path: str | Path) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current_heading: str | None = None
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        match = HEADING_RE.match(line)
+        if match:
+            current_heading = normalize_text(match.group(1))
+            sections[current_heading] = []
+        elif current_heading is not None:
+            sections[current_heading].append(line)
+
+    return {
+        heading: "\n".join(lines).strip()
+        for heading, lines in sections.items()
+    }
+
+
+def check_form_limits(schema_path: str | Path, answers_path: str | Path) -> CheckResult:
+    schema = load_yaml(schema_path)
+    fields = schema.get("fields", [])
+    if not isinstance(fields, list):
+        return CheckResult(
+            "form_limits",
+            "BLOCKED",
+            "Form schema fields must be a list.",
+            [{"reason": "invalid_schema"}],
+        )
+
+    answers = parse_answer_sections(answers_path)
+    details: list[dict[str, Any]] = []
+
+    for item in fields:
+        if not isinstance(item, dict):
+            details.append({"reason": "invalid_field_schema"})
+            continue
+        field_id = str(item.get("id") or "").strip()
+        heading = str(item.get("heading") or "").strip()
+        answer = answers.get(normalize_text(heading), "")
+        required = bool(item.get("required", False))
+        max_length = item.get("max_length")
+
+        if required and not answer:
+            details.append({"field": field_id, "heading": heading, "reason": "missing_required"})
+            continue
+        if max_length is not None:
+            try:
+                limit = int(max_length)
+            except (TypeError, ValueError):
+                details.append({"field": field_id, "reason": "invalid_max_length"})
+                continue
+            if len(answer) > limit:
+                details.append(
+                    {
+                        "field": field_id,
+                        "heading": heading,
+                        "reason": "over_limit",
+                        "length": len(answer),
+                        "max_length": limit,
+                    }
+                )
+
+    if details:
+        return CheckResult("form_limits", "FAIL", "Application answers need correction.", details)
+    return CheckResult("form_limits", "PASS", "Application answers satisfy the configured limits.")
+
+
+def check_lifecycle(policy_path: str | Path, jobs_dir: str | Path) -> CheckResult:
+    policy = load_yaml(policy_path)
+    states = {normalize_text(value) for value in policy.get("states", [])}
+    required_fields = policy.get("required_fields", {})
+    if not states or not isinstance(required_fields, dict):
+        return CheckResult(
+            "lifecycle",
+            "BLOCKED",
+            "Lifecycle policy is incomplete.",
+            [{"reason": "invalid_policy"}],
+        )
+
+    details: list[dict[str, Any]] = []
+    for path, metadata in iter_job_records(jobs_dir):
+        state = normalize_text(metadata.get("triage_state"))
+        if state not in states:
+            details.append(
+                {
+                    "path": path.name,
+                    "reason": "unknown_state" if state else "missing_state",
+                    "state": state or None,
+                }
+            )
+            continue
+
+        required_for_state = required_fields.get(state, [])
+        if not isinstance(required_for_state, list):
+            details.append({"path": path.name, "reason": "invalid_policy_state", "state": state})
+            continue
+        for field_name in required_for_state:
+            if not metadata.get(str(field_name)):
+                details.append(
+                    {
+                        "path": path.name,
+                        "reason": "missing_required_field",
+                        "state": state,
+                        "field": str(field_name),
+                    }
+                )
+
+    if details:
+        return CheckResult("lifecycle", "FAIL", "Workflow lifecycle metadata is inconsistent.", details)
+    return CheckResult("lifecycle", "PASS", "Workflow lifecycle metadata is consistent.")
+
+
+def as_tristate(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    normalized = normalize_text(value)
+    if normalized in {"yes", "true", "provided", "required"}:
+        return True
+    if normalized in {"no", "false", "not provided", "not required"}:
+        return False
+    return None
+
+
+def evaluate_eligibility(policy_path: str | Path, job: dict[str, Any]) -> CheckResult:
+    policy = load_yaml(policy_path)
+    eligible_regions = {normalize_text(value) for value in policy.get("eligible_regions", [])}
+    allow_sponsorship = bool(policy.get("allow_outside_regions_with_sponsorship", False))
+    relocation_allowed = bool(policy.get("relocation_allowed", False))
+
+    hiring_region = normalize_text(job.get("hiring_region"))
+    relocation_required = as_tristate(job.get("relocation_required"))
+    sponsorship_required = as_tristate(job.get("sponsorship_required"))
+    sponsorship_provided = as_tristate(job.get("sponsorship_provided"))
+
+    if relocation_required is True and not relocation_allowed:
+        return CheckResult(
+            "eligibility",
+            "FAIL",
+            "The role requires relocation that the policy does not allow.",
+            [{"reason": "relocation_not_allowed"}],
+        )
+
+    if not hiring_region:
+        return CheckResult(
+            "eligibility",
+            "REVIEW",
+            "Hiring region is not known.",
+            [{"reason": "missing_hiring_region"}],
+        )
+
+    if hiring_region in eligible_regions:
+        if sponsorship_required is True and sponsorship_provided is False:
+            return CheckResult(
+                "eligibility",
+                "FAIL",
+                "Required sponsorship is not provided.",
+                [{"reason": "sponsorship_unavailable"}],
+            )
+        if sponsorship_required is True and sponsorship_provided is None:
+            return CheckResult(
+                "eligibility",
+                "REVIEW",
+                "Sponsorship availability needs confirmation.",
+                [{"reason": "sponsorship_unknown"}],
+            )
+        return CheckResult("eligibility", "PASS", "The role matches the configured eligibility policy.")
+
+    if not allow_sponsorship:
+        return CheckResult(
+            "eligibility",
+            "FAIL",
+            "The hiring region is outside the configured eligible regions.",
+            [{"reason": "region_not_eligible", "hiring_region": hiring_region}],
+        )
+    if sponsorship_provided is True:
+        return CheckResult(
+            "eligibility",
+            "PASS",
+            "The role is outside the configured regions but sponsorship is provided.",
+        )
+    if sponsorship_provided is False:
+        return CheckResult(
+            "eligibility",
+            "FAIL",
+            "The role is outside the configured regions and sponsorship is unavailable.",
+            [{"reason": "sponsorship_unavailable", "hiring_region": hiring_region}],
+        )
+    return CheckResult(
+        "eligibility",
+        "REVIEW",
+        "The role needs sponsorship confirmation.",
+        [{"reason": "sponsorship_unknown", "hiring_region": hiring_region}],
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    duplicate = subparsers.add_parser("duplicate", help="Check a candidate job against local records.")
+    duplicate.add_argument("--jobs-dir", type=Path, required=True)
+    duplicate.add_argument("--company", required=True)
+    duplicate.add_argument("--role-title", required=True)
+    duplicate.add_argument("--location", default="")
+    duplicate.add_argument("--work-model", default="")
+    duplicate.add_argument("--source-url", required=True)
+
+    form_limits = subparsers.add_parser("form-limits", help="Validate Markdown answers against field limits.")
+    form_limits.add_argument("--schema", type=Path, required=True)
+    form_limits.add_argument("--answers", type=Path, required=True)
+
+    lifecycle = subparsers.add_parser("lifecycle", help="Validate job lifecycle metadata.")
+    lifecycle.add_argument("--policy", type=Path, required=True)
+    lifecycle.add_argument("--jobs-dir", type=Path, required=True)
+
+    eligibility = subparsers.add_parser("eligibility", help="Evaluate a job against a user policy.")
+    eligibility.add_argument("--policy", type=Path, required=True)
+    eligibility.add_argument("--job", type=Path, required=True)
+
+    return parser
+
+
+def run_command(args: argparse.Namespace) -> CheckResult:
+    if args.command == "duplicate":
+        return check_duplicate(
+            args.jobs_dir,
+            company=args.company,
+            role_title=args.role_title,
+            location=args.location,
+            work_model=args.work_model,
+            source_url=args.source_url,
+        )
+    if args.command == "form-limits":
+        return check_form_limits(args.schema, args.answers)
+    if args.command == "lifecycle":
+        return check_lifecycle(args.policy, args.jobs_dir)
+    if args.command == "eligibility":
+        return evaluate_eligibility(args.policy, parse_frontmatter(args.job))
+    raise ValueError(f"Unsupported command: {args.command}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = run_command(args)
+    except (OSError, ValueError, yaml.YAMLError) as error:
+        result = CheckResult(
+            args.command,
+            "BLOCKED",
+            "The check could not run.",
+            [{"reason": "input_error", "message": str(error)}],
+        )
+
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+    return EXIT_CODES[result.status]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -25,7 +25,10 @@ def test_primary_pages_use_community_edition_shell() -> None:
         assert 'id="main-content"' in response.text
         assert 'aria-label="Primary navigation"' in response.text
         assert "Theme" in response.text
-        assert "2026 Orcun Sener" in response.text
+        assert "Copyright &copy; 2026" in response.text
+        assert "Orcun Sener" in response.text
+        assert 'href="https://github.com/rcnsnr/job-search-workflow"' in response.text
+        assert 'target="_blank" rel="noopener noreferrer"' in response.text
         assert "Noncommercial use only" in response.text
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -25,6 +25,8 @@ def test_primary_pages_use_community_edition_shell() -> None:
         assert 'id="main-content"' in response.text
         assert 'aria-label="Primary navigation"' in response.text
         assert "Theme" in response.text
+        assert "2026 Orcun Sener" in response.text
+        assert "Noncommercial use only" in response.text
 
 
 def test_public_dashboard_has_no_retired_private_product_name() -> None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sys
+from importlib import util
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER_PATH = ROOT / "dashboard" / "server.py"
+SPEC = util.spec_from_file_location("dashboard_server", SERVER_PATH)
+assert SPEC and SPEC.loader
+server = util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = server
+SPEC.loader.exec_module(server)
+client = TestClient(server.app)
+
+
+def test_primary_pages_use_community_edition_shell() -> None:
+    for path in ("/", "/pipeline", "/jobs", "/profile", "/scoring"):
+        response = client.get(path)
+
+        assert response.status_code == 200
+        assert "Job Search Workflow Community Edition" in response.text
+        assert 'id="main-content"' in response.text
+        assert 'aria-label="Primary navigation"' in response.text
+        assert "Theme" in response.text
+
+
+def test_public_dashboard_has_no_retired_private_product_name() -> None:
+    retired_name = "career" + "ops"
+
+    for path in ("/", "/pipeline", "/jobs", "/profile", "/scoring"):
+        response = client.get(path)
+
+        assert retired_name not in response.text.lower()
+
+
+def test_overview_summarizes_local_pipeline() -> None:
+    response = client.get("/")
+
+    assert "Workspace overview" in response.text
+    assert "Pipeline snapshot" in response.text
+    assert "Needs attention" in response.text
+    assert "Local files" in response.text
+
+
+def test_pipeline_renders_every_stage_without_horizontal_board_contract() -> None:
+    response = client.get("/pipeline")
+
+    assert response.status_code == 200
+    assert 'class="pipeline-grid"' in response.text
+    for stage in server.PIPELINE_STAGES:
+        assert f'data-stage="{stage}"' in response.text
+
+
+def test_jobs_page_has_local_filters_and_compact_dates() -> None:
+    response = client.get("/jobs")
+
+    assert response.status_code == 200
+    assert 'id="job-search"' in response.text
+    assert 'id="job-stage"' in response.text
+    assert "2026-07-01" in response.text
+    assert "2026-07-01T00:00:00" not in response.text
+
+
+def test_format_date_normalizes_iso_timestamp() -> None:
+    assert server.format_compact_date("2026-07-21T00:00:00+03:00") == "2026-07-21"
+    assert server.format_compact_date("2026-07-21") == "2026-07-21"
+    assert server.format_compact_date("") == "Not provided"
+
+
+def test_pipeline_stage_prefers_generic_triage_state() -> None:
+    assert server.infer_stage({"triage_state": "captured"}, "") == "new"
+    assert server.infer_stage({"triage_state": "triaged_apply"}, "") == "shortlist"
+    assert server.infer_stage({"triage_state": "triaged_reject"}, "") == "reject"
+
+
+def test_markdown_rendering_removes_executable_content() -> None:
+    rendered = server.render_safe_markdown(
+        "# Safe heading\n\n<script>alert('unsafe')</script>\n\n"
+        "[unsafe link](javascript:alert('unsafe'))\n\n| A | B |\n| - | - |\n| 1 | 2 |"
+    )
+
+    assert "<h1>Safe heading</h1>" in rendered
+    assert "<table>" in rendered
+    assert "<script" not in rendered
+    assert "javascript:" not in rendered
+
+
+def test_cards_api_remains_available() -> None:
+    response = client.get("/api/cards")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload
+    assert {"filename", "title", "company", "stage"} <= payload[0].keys()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -48,6 +48,15 @@ def test_overview_summarizes_local_pipeline() -> None:
     assert "Pipeline snapshot" in response.text
     assert "Needs attention" in response.text
     assert "Local files" in response.text
+    assert "Your support helps keep the Community Edition improving" in response.text
+    assert 'href="https://github.com/sponsors/rcnsnr"' in response.text
+
+
+def test_demo_workspace_covers_the_complete_pipeline() -> None:
+    cards = server.load_job_cards_from(server.FIXTURES_DIR)
+
+    assert len(cards) >= 10
+    assert set(server.PIPELINE_STAGES) <= {card.stage for card in cards}
 
 
 def test_pipeline_renders_every_stage_without_horizontal_board_contract() -> None:
@@ -69,6 +78,77 @@ def test_jobs_page_has_local_filters_and_compact_dates() -> None:
     assert "2026-07-01T00:00:00" not in response.text
 
 
+def test_job_detail_lists_only_application_documents() -> None:
+    response = client.get("/posting/sample-job-posting.md")
+
+    assert response.status_code == 200
+    assert 'class="posting-layout"' in response.text
+    assert "Application files" in response.text
+    assert "sample-cv.pdf" in response.text
+    assert "sample-cv.tex" not in response.text
+    assert "sample-cover-letter.md" in response.text
+    assert "sample-application-answers.md" in response.text
+    assert "sample-triage-run.md" not in response.text
+    assert "sample-quality-audit.md" not in response.text
+    assert "source_id:" not in response.text
+    assert "Extracted Facts" in response.text
+
+
+def test_demo_pdf_label_does_not_expose_a_fake_file() -> None:
+    response = client.get(
+        "/application-file/sample-job-posting.md/sample-cv.pdf"
+    )
+
+    assert response.status_code == 404
+
+
+def test_application_document_route_rejects_non_application_fixture() -> None:
+    response = client.get(
+        "/application-file/sample-job-posting.md/sample-triage-run.md"
+    )
+
+    assert response.status_code == 404
+
+
+def test_application_document_route_renders_markdown() -> None:
+    response = client.get(
+        "/application-file/sample-job-posting.md/sample-cover-letter.md"
+    )
+
+    assert response.status_code == 200
+    assert "Cover letter" in response.text
+    assert "Dear Hiring Team" in response.text
+
+
+def test_application_documents_use_posting_specific_package(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    packages = tmp_path / "applications"
+    package = packages / "orion-role"
+    package.mkdir(parents=True)
+    (package / "orion-cv.pdf").write_bytes(b"%PDF-1.4")
+    (package / "orion-cv.tex").write_text("Source only", encoding="utf-8")
+    (package / "cover-letter.md").write_text("Dear team", encoding="utf-8")
+    (package / "application-answers.md").write_text("Answer", encoding="utf-8")
+    (package / "triage-notes.md").write_text("Internal", encoding="utf-8")
+    (package / "nested").mkdir()
+    (package / "nested" / "resume.pdf").write_bytes(b"%PDF-1.4")
+    monkeypatch.setattr(server, "APPLICATIONS_DIR", packages)
+
+    documents = server.load_application_documents("orion-role.md")
+
+    assert [document.label for document in documents] == [
+        "CV",
+        "Cover letter",
+        "Application answers",
+    ]
+    assert {document.filename for document in documents} == {
+        "orion-cv.pdf",
+        "cover-letter.md",
+        "application-answers.md",
+    }
+
+
 def test_profile_surfaces_career_direction_and_decision_criteria() -> None:
     response = client.get("/profile")
 
@@ -77,6 +157,27 @@ def test_profile_surfaces_career_direction_and_decision_criteria() -> None:
     assert "Decision criteria" in response.text
     assert "AI-enabled platform engineering" in response.text
     assert "No recurring overnight on-call" in response.text
+
+
+def test_scoring_explains_quality_penalties_in_plain_language() -> None:
+    response = client.get("/scoring")
+
+    assert response.status_code == 200
+    assert "How quality risks change a score" in response.text
+    assert "Inactive posting risk" in response.text
+    assert "Unfair process risk" in response.text
+    assert "Delivery chaos risk" in response.text
+    assert "No score change" in response.text
+    assert "Subtract 1.5 points" in response.text
+    assert "Two or more high risks" in response.text
+    assert "4.2 fit score" in response.text
+
+
+def test_format_score_adjustment_uses_plain_language() -> None:
+    assert server.format_score_adjustment(0.0) == "No score change"
+    assert server.format_score_adjustment(-0.5) == "Subtract 0.5 points"
+    assert server.format_score_adjustment(-1.0) == "Subtract 1.0 point"
+    assert server.format_score_adjustment("unknown") == "Not configured"
 
 
 def test_format_date_normalizes_iso_timestamp() -> None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -64,6 +64,16 @@ def test_jobs_page_has_local_filters_and_compact_dates() -> None:
     assert "2026-07-01T00:00:00" not in response.text
 
 
+def test_profile_surfaces_career_direction_and_decision_criteria() -> None:
+    response = client.get("/profile")
+
+    assert response.status_code == 200
+    assert "Career Direction" in response.text
+    assert "Decision criteria" in response.text
+    assert "AI-enabled platform engineering" in response.text
+    assert "No recurring overnight on-call" in response.text
+
+
 def test_format_date_normalizes_iso_timestamp() -> None:
     assert server.format_compact_date("2026-07-21T00:00:00+03:00") == "2026-07-21"
     assert server.format_compact_date("2026-07-21") == "2026-07-21"

--- a/tests/test_documentation_contract.py
+++ b/tests/test_documentation_contract.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]*\]\(([^)]+)\)")
+
+
+def test_local_markdown_links_resolve() -> None:
+    missing: list[str] = []
+    for path in sorted(ROOT.rglob("*.md")):
+        if "node_modules" in path.parts:
+            continue
+        content = path.read_text(encoding="utf-8")
+        for match in MARKDOWN_LINK.finditer(content):
+            target = match.group(1).strip().split()[0].strip("<>")
+            if target.startswith(("#", "http://", "https://", "mailto:")):
+                continue
+            relative = target.split("#", 1)[0]
+            if relative and not (path.parent / relative).resolve().exists():
+                line = content.count("\n", 0, match.start()) + 1
+                missing.append(f"{path.relative_to(ROOT)}:{line}: {target}")
+
+    assert missing == []
+
+
+def test_setup_guide_matches_current_workflow_and_node_contract() -> None:
+    guide = (ROOT / "docs" / "setup-and-verification.md").read_text(encoding="utf-8")
+
+    assert ".github/workflows/setup-audit.yml" in guide
+    assert "Node.js >= 22.12 is required" in guide
+    assert "Node.js >= 18 is required" not in guide
+
+
+def test_docx_reference_path_matches_validator_contract() -> None:
+    getting_started = (ROOT / "docs" / "getting-started" / "GETTING_STARTED.md").read_text(
+        encoding="utf-8"
+    )
+    document_mode = (ROOT / "modes" / "05_DOCUMENT_OUTPUT.md").read_text(encoding="utf-8")
+
+    for content in (getting_started, document_mode):
+        assert "exports/cv-reference.docx" in content
+        assert "templates/cv-reference.docx" not in content
+        assert "exports/cv-variants-2026-06-21" not in content

--- a/tests/test_license_policy.py
+++ b/tests/test_license_policy.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from importlib import util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "check_license_policy.py"
+SPEC = util.spec_from_file_location("check_license_policy", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+license_policy = util.module_from_spec(SPEC)
+SPEC.loader.exec_module(license_policy)
+
+
+def test_current_repository_license_policy_passes() -> None:
+    assert license_policy.check_license_policy(ROOT) == []
+
+
+def test_extension_mit_metadata_is_rejected(tmp_path: Path) -> None:
+    extension_dir = tmp_path / "tools" / "browser-extension"
+    extension_dir.mkdir(parents=True)
+    package = {"license": "MIT"}
+    (extension_dir / "package.json").write_text(json.dumps(package), encoding="utf-8")
+
+    errors = license_policy.check_extension_metadata(tmp_path)
+
+    assert any("package.json" in error and "MIT" in error for error in errors)
+
+
+def test_modified_canonical_license_is_rejected(tmp_path: Path) -> None:
+    (tmp_path / "LICENSE").write_text("modified license\n", encoding="utf-8")
+
+    errors = license_policy.check_canonical_license(tmp_path)
+
+    assert any("official PolyForm" in error for error in errors)
+
+
+def test_missing_pull_request_license_confirmation_is_rejected(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    template = repository / ".github" / "pull_request_template.md"
+    template.parent.mkdir(parents=True)
+
+    errors = license_policy.check_policy_documents(repository)
+
+    assert ".github/pull_request_template.md is missing" in errors

--- a/tests/test_linkedin_capture_server.py
+++ b/tests/test_linkedin_capture_server.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 import pytest
 from fastapi.testclient import TestClient
 
-# Make public/scripts/ importable during tests
+# Make repository scripts importable during tests.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
 
 from linkedin_capture_server import create_app

--- a/tests/test_md_to_tex.py
+++ b/tests/test_md_to_tex.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+from importlib import util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONVERTER_PATH = ROOT / "scripts" / "md_to_tex.py"
+SPEC = util.spec_from_file_location("md_to_tex", CONVERTER_PATH)
+assert SPEC and SPEC.loader
+md_to_tex = util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = md_to_tex
+SPEC.loader.exec_module(md_to_tex)
+
+
+def test_convert_closes_each_itemize_block(tmp_path: Path) -> None:
+    source = tmp_path / "sample-cv.md"
+    source.write_text(
+        "---\n"
+        "title: Example Candidate\n"
+        "author:\n"
+        "  - City, Country | person@example.com | +1-555-0100\n"
+        "  - LinkedIn: linkedin.com/in/example | GitHub: github.com/example\n"
+        "---\n\n"
+        "## Experience\n\n"
+        "- Built a reliable service.\n"
+        "- Improved deployment checks.\n\n"
+        "## Skills\n\n"
+        "Python and Linux.\n",
+        encoding="utf-8",
+    )
+
+    rendered = md_to_tex.convert(source)
+
+    assert rendered.count("\\begin{itemize}") == 1
+    assert rendered.count("\\end{itemize}") == 1
+    assert rendered.endswith("\\end{document}\n")

--- a/tests/test_scan_pii.py
+++ b/tests/test_scan_pii.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib import util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCANNER = ROOT / "scripts" / "scan_pii.py"
+SPEC = util.spec_from_file_location("scan_pii", SCANNER)
+assert SPEC and SPEC.loader
+scan_pii = util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = scan_pii
+SPEC.loader.exec_module(scan_pii)
+
+
+def test_scan_path_finds_denied_content_outside_legacy_directories(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    denied_name = "career" + "ops"
+    (docs_dir / "note.md").write_text(f"Retired name: {denied_name}\n", encoding="utf-8")
+
+    findings = scan_pii.scan_path(tmp_path)
+
+    assert [(finding.path, finding.description) for finding in findings] == [
+        ("docs/note.md", "retired private product name"),
+    ]
+
+
+def test_allowed_email_does_not_hide_denied_content_on_same_line(tmp_path: Path) -> None:
+    owner_path = "/home/" + "orcun/private"
+    (tmp_path / "README.md").write_text(
+        f"Contact demo@example.com; never publish {owner_path}\n",
+        encoding="utf-8",
+    )
+
+    findings = scan_pii.scan_path(tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].description == "owner home directory path"
+
+
+def test_noreply_and_example_addresses_are_allowed(tmp_path: Path) -> None:
+    (tmp_path / "metadata.toml").write_text(
+        "maintainer = 'rcnsnr@users.noreply.github.com'\n"
+        "sample = 'person@example.com'\n",
+        encoding="utf-8",
+    )
+
+    assert scan_pii.scan_path(tmp_path) == []
+
+
+def test_real_email_address_is_denied(tmp_path: Path) -> None:
+    private_address = "person@" + "gmail.com"
+    (tmp_path / "metadata.yaml").write_text(f"email: {private_address}\n", encoding="utf-8")
+
+    findings = scan_pii.scan_path(tmp_path)
+
+    assert len(findings) == 1
+    assert findings[0].description == "email address"
+
+
+def test_generated_and_dependency_directories_are_skipped(tmp_path: Path) -> None:
+    denied_name = "career" + "ops"
+    dependency_dir = tmp_path / "node_modules" / "package"
+    dependency_dir.mkdir(parents=True)
+    (dependency_dir / "README.md").write_text(denied_name, encoding="utf-8")
+
+    assert scan_pii.scan_path(tmp_path) == []
+
+
+def test_cli_respects_explicit_path(tmp_path: Path) -> None:
+    clean_dir = tmp_path / "clean"
+    dirty_dir = tmp_path / "dirty"
+    clean_dir.mkdir()
+    dirty_dir.mkdir()
+    (clean_dir / "README.md").write_text("Generic public content\n", encoding="utf-8")
+    private_address = "person@" + "gmail.com"
+    (dirty_dir / "README.md").write_text(private_address, encoding="utf-8")
+
+    clean = subprocess.run(
+        [sys.executable, str(SCANNER), "--path", str(clean_dir)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    dirty = subprocess.run(
+        [sys.executable, str(SCANNER), "--path", str(dirty_dir)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert clean.returncode == 0
+    assert dirty.returncode == 1
+    assert "README.md:1: email address" in dirty.stderr

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -76,7 +76,7 @@ class SetupScriptTests(unittest.TestCase):
     def test_fixture_copy_preserves_existing_user_file(self) -> None:
         root = self.make_repo()
         (root / "fixtures").mkdir()
-        (root / "fixtures" / "sample-career_profile.md").write_text("# Sample\n", encoding="utf-8")
+        (root / "fixtures" / "sample-profile.md").write_text("# Sample\n", encoding="utf-8")
         (root / "fixtures" / "sample-target_roles.md").write_text("# Roles\n", encoding="utf-8")
         (root / "user_data").mkdir()
         profile = root / "user_data" / "career_profile.md"
@@ -85,6 +85,17 @@ class SetupScriptTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(profile.read_text(encoding="utf-8"), "# Existing\n")
         self.assertEqual((root / "user_data" / "target_roles.md").read_text(encoding="utf-8"), "# Roles\n")
+
+    def test_fixture_copy_uses_repository_sample_profile(self) -> None:
+        root = self.make_repo()
+        (root / "fixtures").mkdir()
+        (root / "fixtures" / "sample-profile.md").write_text("# Sample\n", encoding="utf-8")
+
+        result = self.run_setup(root)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        profile = root / "user_data" / "career_profile.md"
+        self.assertEqual(profile.read_text(encoding="utf-8"), "# Sample\n")
 
     def test_invalid_python_file_fails_setup(self) -> None:
         root = self.make_repo()

--- a/tests/test_verify_no_turkish.py
+++ b/tests/test_verify_no_turkish.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import sys
+from importlib import util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER_PATH = ROOT / "scripts" / "verify_no_turkish.py"
+SPEC = util.spec_from_file_location("verify_no_turkish", CHECKER_PATH)
+assert SPEC and SPEC.loader
+verify_no_turkish = util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = verify_no_turkish
+SPEC.loader.exec_module(verify_no_turkish)
+
+
+def test_additional_allowlist_suppresses_configured_word() -> None:
+    findings: list[str] = []
+    candidate = "bas" + "vuru"
+    allowed = verify_no_turkish.ALLOWED | {candidate}
+
+    verify_no_turkish.check_line(
+        candidate,
+        Path("fixture.md"),
+        1,
+        findings,
+        allowed,
+    )
+
+    assert findings == []
+
+
+def test_word_is_reported_without_additional_allowlist() -> None:
+    findings: list[str] = []
+    candidate = "bas" + "vuru"
+
+    verify_no_turkish.check_line(
+        candidate,
+        Path("fixture.md"),
+        1,
+        findings,
+        verify_no_turkish.ALLOWED,
+    )
+
+    assert findings

--- a/tests/test_workflow_guard.py
+++ b/tests/test_workflow_guard.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import sys
+from importlib import util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GUARD_PATH = ROOT / "scripts" / "workflow_guard.py"
+SPEC = util.spec_from_file_location("workflow_guard", GUARD_PATH)
+assert SPEC and SPEC.loader
+workflow_guard = util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = workflow_guard
+SPEC.loader.exec_module(workflow_guard)
+
+
+def write_job(path: Path, **fields: object) -> None:
+    frontmatter = "\n".join(f"{key}: {value}" for key, value in fields.items())
+    path.write_text(f"---\n{frontmatter}\n---\n\n## Notes\n\nFixture.\n", encoding="utf-8")
+
+
+def test_duplicate_check_matches_normalized_source_url(tmp_path: Path) -> None:
+    write_job(
+        tmp_path / "existing.md",
+        source_id="fixture-1",
+        source_url="https://example.com/jobs/42?ref=feed",
+        company="Example Labs",
+        role_title="Platform Engineer",
+        location="Remote",
+        work_model="remote",
+        triage_state="captured",
+    )
+
+    result = workflow_guard.check_duplicate(
+        tmp_path,
+        company="Another Company",
+        role_title="Another Role",
+        location="Elsewhere",
+        work_model="hybrid",
+        source_url="https://example.com/jobs/42",
+    )
+
+    assert result.status == "FAIL"
+    assert result.details[0]["reason"] == "source_url"
+
+
+def test_duplicate_check_passes_for_distinct_identity(tmp_path: Path) -> None:
+    write_job(
+        tmp_path / "existing.md",
+        source_id="fixture-1",
+        source_url="https://example.com/jobs/42",
+        company="Example Labs",
+        role_title="Platform Engineer",
+        location="Remote",
+        work_model="remote",
+        triage_state="captured",
+    )
+
+    result = workflow_guard.check_duplicate(
+        tmp_path,
+        company="Northwind",
+        role_title="Site Reliability Engineer",
+        location="Berlin",
+        work_model="hybrid",
+        source_url="https://example.org/jobs/9",
+    )
+
+    assert result.status == "PASS"
+
+
+def test_duplicate_check_preserves_identity_query_parameters(tmp_path: Path) -> None:
+    write_job(
+        tmp_path / "existing.md",
+        source_id="fixture-1",
+        source_url="https://example.com/jobs?jobId=42&utm_source=feed",
+        company="Example Labs",
+        role_title="Platform Engineer",
+        location="Remote",
+        work_model="remote",
+        triage_state="captured",
+    )
+
+    result = workflow_guard.check_duplicate(
+        tmp_path,
+        company="Example Labs",
+        role_title="Infrastructure Engineer",
+        location="Remote",
+        work_model="remote",
+        source_url="https://example.com/jobs?jobId=43&utm_source=feed",
+    )
+
+    assert result.status == "PASS"
+
+
+def test_form_limits_report_overflow_and_missing_required_answer(tmp_path: Path) -> None:
+    schema = tmp_path / "form.yaml"
+    answers = tmp_path / "answers.md"
+    schema.write_text(
+        "fields:\n"
+        "  - id: motivation\n"
+        "    heading: Why this role?\n"
+        "    required: true\n"
+        "    max_length: 10\n"
+        "  - id: portfolio\n"
+        "    heading: Portfolio URL\n"
+        "    required: true\n"
+        "    max_length: 100\n",
+        encoding="utf-8",
+    )
+    answers.write_text("## Why this role?\n\nThis answer is too long.\n", encoding="utf-8")
+
+    result = workflow_guard.check_form_limits(schema, answers)
+
+    assert result.status == "FAIL"
+    assert {detail["reason"] for detail in result.details} == {"over_limit", "missing_required"}
+
+
+def test_form_limits_pass_when_answers_fit(tmp_path: Path) -> None:
+    schema = tmp_path / "form.yaml"
+    answers = tmp_path / "answers.md"
+    schema.write_text(
+        "fields:\n  - id: motivation\n    heading: Why this role?\n    required: true\n    max_length: 20\n",
+        encoding="utf-8",
+    )
+    answers.write_text("## Why this role?\n\nGood fit.\n", encoding="utf-8")
+
+    assert workflow_guard.check_form_limits(schema, answers).status == "PASS"
+
+
+def test_lifecycle_check_rejects_unknown_or_incomplete_state(tmp_path: Path) -> None:
+    policy = tmp_path / "lifecycle.yaml"
+    jobs = tmp_path / "jobs"
+    jobs.mkdir()
+    policy.write_text(
+        "states: [captured, applied, closed]\n"
+        "required_fields:\n"
+        "  applied: [applied_date]\n",
+        encoding="utf-8",
+    )
+    write_job(
+        jobs / "missing-date.md",
+        source_id="fixture-2",
+        source_url="https://example.com/jobs/2",
+        company="Example Labs",
+        role_title="Engineer",
+        triage_state="applied",
+    )
+    write_job(
+        jobs / "unknown.md",
+        source_id="fixture-3",
+        source_url="https://example.com/jobs/3",
+        company="Example Labs",
+        role_title="Engineer",
+        triage_state="invented",
+    )
+
+    result = workflow_guard.check_lifecycle(policy, jobs)
+
+    assert result.status == "FAIL"
+    assert {detail["reason"] for detail in result.details} == {"missing_required_field", "unknown_state"}
+
+
+def test_eligibility_is_policy_driven_and_can_pass_fail_or_review(tmp_path: Path) -> None:
+    policy = tmp_path / "eligibility.yaml"
+    policy.write_text(
+        "eligible_regions: [home, global]\n"
+        "allow_outside_regions_with_sponsorship: true\n"
+        "relocation_allowed: false\n",
+        encoding="utf-8",
+    )
+
+    assert workflow_guard.evaluate_eligibility(
+        policy,
+        {"hiring_region": "home", "relocation_required": False},
+    ).status == "PASS"
+    assert workflow_guard.evaluate_eligibility(
+        policy,
+        {"hiring_region": "outside", "sponsorship_provided": False},
+    ).status == "FAIL"
+    assert workflow_guard.evaluate_eligibility(
+        policy,
+        {"hiring_region": "outside", "sponsorship_provided": "unknown"},
+    ).status == "REVIEW"

--- a/tools/browser-extension/content/autoscan.js
+++ b/tools/browser-extension/content/autoscan.js
@@ -1,7 +1,7 @@
 // content/autoscan.js
 // Unattended scan loop for LinkedIn Jobs -> Workflow capture server
 (function () {
-  if (window.__careerOpsAutoScanInitialized) {
+  if (window.__jswAutoScanInitialized) {
     return;
   }
 
@@ -332,7 +332,7 @@
     });
   }
 
-  window.__careerOpsAutoScanInitialized = true;
+  window.__jswAutoScanInitialized = true;
 
   window.WorkflowAutoScan = {
     start,

--- a/tools/browser-extension/package-lock.json
+++ b/tools/browser-extension/package-lock.json
@@ -12,10 +12,10 @@
         "eslint": "^8.57.1",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
-        "puppeteer": "^24.32.1"
+        "puppeteer": "^25.8.0"
       },
       "engines": {
-        "node": ">=18.0.0",
+        "node": ">=22.12.0",
         "npm": ">=9.0.0"
       }
     },
@@ -875,9 +875,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1451,38 +1451,195 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
-      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.2.1.tgz",
+      "integrity": "sha512-KDz+3qDRdBAlRlMjmKyj6dEs33YHTk/xRHEENSXq6TNnhgoU15ruSHtEBeVF6OZ9tBDY55Se4P0nFMNsipzU9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.3",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.4",
-        "tar-fs": "^3.1.1",
-        "yargs": "^17.7.2"
+        "modern-tar": "^0.8.0",
+        "yargs": "^18.0.0"
       },
       "bin": {
-        "browsers": "lib/cjs/main-cli.js"
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+    "node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+      "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -1511,13 +1668,6 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
-    },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -1654,17 +1804,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
@@ -2155,34 +2294,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/babel-jest": {
       "version": "30.4.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
@@ -2289,91 +2400,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
-      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
-      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
-      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.8.1",
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
-      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
@@ -2387,20 +2413,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/basic-ftp": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
-      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2450,16 +2466,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -2538,14 +2544,17 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
-      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -2681,33 +2690,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cosmiconfig": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2735,16 +2717,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/data-urls": {
@@ -2818,21 +2790,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2844,9 +2801,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1608973",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
-      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
+      "version": "0.0.1666840",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1666840.tgz",
+      "integrity": "sha512-gCcO42XCHKEs7Ag0S7aGYsnJ7hlgrO3qderYqeiY0Eqk+0GFfuvT13IA0hHreJTa2KCdDVyGMeOhdMNmrrTjVg==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -2897,16 +2854,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2918,16 +2865,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/error-ex": {
@@ -2961,28 +2898,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -3150,16 +3065,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3219,54 +3124,10 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3302,16 +3163,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3425,6 +3276,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3446,21 +3310,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
-      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -3499,9 +3348,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3710,16 +3559,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4532,9 +4371,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4682,6 +4521,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -4808,6 +4660,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/modern-tar": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4837,16 +4699,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/netmask": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
-      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4981,40 +4833,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -5120,13 +4938,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5266,64 +5077,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5335,44 +5088,43 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.43.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.1.tgz",
-      "integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.8.0.tgz",
+      "integrity": "sha512-3gcUJ+Jfodb5zNa/lWLZukBUwYiRIwAc8WRICoqfi+ZYmNWqpsPFyanTU3Gw/lhgII9aotVbAmhT6/NKHWgyUA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.2",
-        "chromium-bidi": "14.0.0",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1608973",
-        "puppeteer-core": "24.43.1",
+        "@puppeteer/browsers": "3.2.1",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1666840",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.8.0",
         "typed-query-selector": "^2.12.2"
       },
       "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+        "puppeteer": "lib/puppeteer/node/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.43.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
-      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.8.0.tgz",
+      "integrity": "sha512-LDOrawV8vfCVk+yLj2ozvajNP4Sv3OV9y3Tpiyy2g2Z+aQlbcozP6KJfI4iSBq7YQER+86ihEtPa5ioiZyWxMQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.2",
-        "chromium-bidi": "14.0.0",
-        "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1608973",
+        "@puppeteer/browsers": "3.2.1",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1666840",
         "typed-query-selector": "^2.12.2",
-        "webdriver-bidi-protocol": "0.4.1",
-        "ws": "^8.20.0"
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/pure-rand": {
@@ -5629,47 +5381,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5719,18 +5430,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string-length": {
@@ -5913,44 +5612,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
-      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5986,16 +5647,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -6063,7 +5714,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6233,9 +5885,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
-      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -6540,17 +6192,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/tools/browser-extension/package-lock.json
+++ b/tools/browser-extension/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "job-search-workflow-capture",
       "version": "2.0.0",
-      "license": "MIT",
+      "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "eslint": "^8.57.1",
         "jest": "^30.2.0",

--- a/tools/browser-extension/package.json
+++ b/tools/browser-extension/package.json
@@ -25,10 +25,10 @@
     "eslint": "^8.57.1",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
-    "puppeteer": "^24.32.1"
+    "puppeteer": "^25.8.0"
   },
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=22.12.0",
     "npm": ">=9.0.0"
   }
 }

--- a/tools/browser-extension/package.json
+++ b/tools/browser-extension/package.json
@@ -20,7 +20,7 @@
     "browser-extension"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "devDependencies": {
     "eslint": "^8.57.1",
     "jest": "^30.2.0",

--- a/tools/browser-extension/readme.md
+++ b/tools/browser-extension/readme.md
@@ -103,7 +103,10 @@ job-search-workflow-capture/
 
 ## License
 
-This project is released under the MIT License. See [LICENSE](LICENSE) for details.
+This extension is part of Job Search Workflow Community Edition and uses the
+repository's [PolyForm Noncommercial 1.0.0 license](../../LICENSE). Commercial
+use is not granted by this repository; see the
+[Commercial Use and SaaS Boundary](../../COMMERCIAL_USE.md).
 
 ## Contributing
 

--- a/tools/browser-extension/tests/autoscan.test.js
+++ b/tools/browser-extension/tests/autoscan.test.js
@@ -13,7 +13,7 @@ describe("autoscan content script", () => {
 
   beforeEach(() => {
     document.body.innerHTML = "";
-    window.__careerOpsAutoScanInitialized = false;
+  window.__jswAutoScanInitialized = false;
     delete window.WorkflowAutoScan;
     scrollCalls = [];
     window.scrollTo = jest.fn((x, y) => {
@@ -94,7 +94,7 @@ describe("autoscan content script", () => {
 
   afterEach(() => {
     delete window.WorkflowAutoScan;
-    delete window.__careerOpsAutoScanInitialized;
+    delete window.__jswAutoScanInitialized;
   });
 
   function requireAutoscan() {


### PR DESCRIPTION
## Summary

- add the light-first, responsive Community Operations Desk dashboard
- add local profile goals and decision criteria
- add ten fictitious jobs spanning every pipeline stage
- add job-detail application files limited to CV/resume, cover letter, and application answers
- label the sample delivery CV as PDF while excluding LaTeX source from the UI
- move application files into a wide-screen right rail and hide raw frontmatter
- explain scoring penalties in plain language with an adjusted-score example
- add a direct GitHub Sponsors link and persistent ownership/noncommercial notice
- package the local dashboard behind the jsw CLI
- strengthen Python quality, privacy scans, setup contracts, and documentation

## Validation

- 59 Python tests passed
- 150 browser-extension tests passed
- Ruff, compileall, dashboard smoke, ShellCheck, Actionlint, and setup checks passed
- Markdown lint: 50 files, 0 errors
- PII, secret, brand, language, and license-policy checks passed
- npm audit: 0 vulnerabilities on this feature branch
- job detail verified at 1920 x 1200, 1080 x 1800, and 390 x 844 without horizontal overflow
- hosted PR CI passed in run 32299525680
- Linux and Windows Setup Audit passed in run 32299526869

## Merge gates

- [x] Hosted CI passes
- [x] Setup Audit passes on Linux and Windows
- [ ] Main branch protection is restored
- [ ] Maintainer reviews and explicitly approves merge

This PR does not authorize merge, tag, release, deployment, or publication of private CareerOps data.