### PR TITLE
[WP-CAREEROPS-10] Add AI onboarding quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,19 @@ by each user; it does not require a hosted account.
 4. Replace the generated sample files under `user_data/` with your own verified
    information. Fictitious examples remain available under `fixtures/`.
 
+5. Follow the [30-Minute Quickstart](docs/getting-started/QUICKSTART-30MIN.md)
+   to complete one first triage. Before sharing personal material with an AI
+   assistant, read the [AI Assistant Integration Guide](docs/getting-started/AI-ASSISTANT-INTEGRATION.md).
+
 Read the [Setup and Verification Guide](docs/setup-and-verification.md) for the detailed behavior contract, support matrix and troubleshooting steps.
 
 ## Documentation Map
 
 | Need | Guide |
 | --- | --- |
+| First triage in one sitting | [30-Minute Quickstart](docs/getting-started/QUICKSTART-30MIN.md) |
 | First end-to-end workflow | [Getting Started](docs/getting-started/GETTING_STARTED.md) |
+| Use an AI assistant safely | [AI Assistant Integration Guide](docs/getting-started/AI-ASSISTANT-INTEGRATION.md) |
 | Setup and supported environments | [Setup and Verification](docs/setup-and-verification.md) |
 | Read-only record checks | [Workflow Guards](docs/getting-started/WORKFLOW_GUARDS.md) |
 | Public job-source discovery | [Source Discovery Operations](docs/runbooks/source-discovery-operations.md) |
@@ -95,9 +101,10 @@ The setup scripts do not install missing system packages automatically and do no
 - `docs/runbooks/` - repeatable operational procedures
 - `tools/browser-extension/` - `Job Search Workflow Capture` browser extension source
 - `fixtures/` - fictitious sample data for local demos and tests
+- `templates/` - starter files to copy into your Git-ignored local `user_data/` workspace
 - `dashboard/` - local Community Operations Desk interface
 
-## Browser Extension
+## Advanced: Browser Extension
 
 The `Job Search Workflow Capture` browser extension captures job postings from
 LinkedIn Jobs and exports them as Job Search Workflow Markdown/JSONL, CSV, or JSON. It can
@@ -174,6 +181,10 @@ Windows support is not considered verified unless that job passes.
 
 - Content under `user_data/`, `inbox/jobs/`, `runs/`, `outputs/` and `exports/` is excluded by `.gitignore`.
 - `.gitignore` alone does not guarantee prevention of personal-data leaks.
+- The framework does not send your files to an AI provider. If you paste or
+  upload content to an AI assistant, that selected content is handled by that
+  provider under its own terms. Use the [AI Assistant Integration Guide](docs/getting-started/AI-ASSISTANT-INTEGRATION.md)
+  to choose a narrow sharing path.
 - Before every public contribution or release, run deterministic PII and secret
   scans, perform a manual content review, verify licensing, and confirm that
   Git history contains no unintended private data.

--- a/docs/getting-started/AI-ASSISTANT-INTEGRATION.md
+++ b/docs/getting-started/AI-ASSISTANT-INTEGRATION.md
@@ -1,0 +1,88 @@
+# AI Assistant Integration Guide
+
+Job Search Workflow Community Edition works with assistants that can accept
+pasted text. It does not require an account, an API key, or a connection to an
+AI provider.
+
+## The Safe Default
+
+Use the same portable flow with ChatGPT, Claude, Codex, Cursor, Windsurf, or
+another assistant:
+
+1. Open the mode file for the task, such as
+   [`modes/01_JOB_TRIAGE.md`](../../modes/01_JOB_TRIAGE.md).
+2. Copy the complete mode file into the assistant.
+3. Add only the profile excerpt needed for this task.
+4. Paste the job posting or another task input.
+5. Review the output before saving it into your local workspace.
+
+This method works even when the assistant has no access to your repository.
+
+## Choose What to Share
+
+Start with the smallest useful amount of information.
+
+| Sharing level | Use it when | Include | Keep out by default |
+| --- | --- | --- | --- |
+| Fixture-only practice | You are learning the workflow | Files under `fixtures/` | All personal information |
+| Narrow profile excerpt | You are evaluating one role | Relevant skills, constraints, and selected achievements | Contact details, full history, unrelated applications |
+| Full local document | You have reviewed the provider policy and need broader tailoring | Only the files needed for that task | Repository history, credentials, and unrelated records |
+
+The framework does not send your files to an AI provider. Pasting or uploading
+content to an AI assistant sends that selected content to the provider. Review
+the provider's current privacy, retention, and workspace-access settings before
+sharing personal material.
+
+## Browser Chat and Workspace-Aware Assistants
+
+### Browser Chat
+
+For a browser chat, copy and paste the mode, a narrow profile excerpt, and the
+job posting. Do not assume that a browser-based AI chat can read a local file path. A file path is only a reference on your machine, not a transfer of the file's contents.
+
+### Workspace-Aware Assistant
+
+Tools such as Codex, Cursor, or Windsurf can sometimes read files from a local
+workspace after you grant access. Before doing that:
+
+1. Confirm which folder the tool can access.
+2. Ask it to read only named files, for example `user_data/target_roles.md`.
+3. Avoid broad instructions such as "read everything".
+4. Check the tool and provider settings for cloud processing and retention.
+
+Workspace access can reduce copy and paste, but it does not remove the need to
+understand where the tool processes your content.
+
+## First Triage Prompt Shape
+
+Use this order after pasting the full job-triage mode:
+
+```text
+Use the mode above as the evaluation contract.
+
+Candidate context for this role:
+[paste a narrow, verified profile excerpt]
+
+Job posting:
+[paste the posting]
+
+Return the structured triage result. Mark unsupported facts as Unknown.
+Do not submit an application or modify files.
+```
+
+For a fixture-only rehearsal, replace the candidate context and job posting
+with [`fixtures/sample-profile.md`](../../fixtures/sample-profile.md) and
+[`fixtures/sample-job-posting.md`](../../fixtures/sample-job-posting.md).
+
+## What the Framework Does Not Do
+
+- It does not send your profile, job history, or application records to an AI
+  provider.
+- It does not submit applications, contact recruiters, or change your files
+  automatically.
+- It does not make a decision for you. Read-only workflow guards can report
+  evidence, but you make the final decision.
+
+Continue with the [30-Minute Quickstart](QUICKSTART-30MIN.md) for one complete
+first triage, or use [Getting Started](GETTING_STARTED.md) for the detailed
+workflow.

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -4,6 +4,10 @@ This guide walks you through your first job triage, CV generation, and tracking
 — on macOS, Linux, or Windows.
 
 > **New here?** Read the [README](../../README.md) first for the project overview.
+>
+> **Want the shortest path?** Follow the [30-Minute Quickstart](QUICKSTART-30MIN.md).
+> Before sharing personal material with an AI assistant, read the
+> [AI Assistant Integration Guide](AI-ASSISTANT-INTEGRATION.md).
 
 ---
 
@@ -11,6 +15,7 @@ This guide walks you through your first job triage, CV generation, and tracking
 
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)
+- [Choose an AI Assistant Safely](#choose-an-ai-assistant-safely)
 - [Your First Triage](#your-first-triage)
 - [Generate a Tailored CV](#generate-a-tailored-cv)
 - [Track in the Dashboard](#track-in-the-dashboard)
@@ -153,6 +158,19 @@ npm install -g markdownlint-cli2
 
 ---
 
+## Choose an AI Assistant Safely
+
+This framework works with any assistant that can accept pasted text. The
+portable default is simple: paste the full mode file, then share only the
+smallest profile excerpt and job-posting text needed for that task.
+
+Use the [AI Assistant Integration Guide](AI-ASSISTANT-INTEGRATION.md) to choose
+between a browser chat, a workspace-aware coding assistant, and fixture-only
+practice. The guide explains what a provider can receive and how to avoid
+sharing contact details, full work history, or application records by default.
+
+---
+
 ## Your First Triage
 
 The framework uses `modes/` files as structured prompts. You paste the
@@ -161,11 +179,16 @@ under it.
 
 ### Step 1: Fill Your Profile
 
-Open `user_data/career_profile.md` in your AI assistant and replace the
-placeholders with your real experience, skills, and preferences.
+Open `user_data/career_profile.md` in a local editor and replace the placeholders
+with your real experience, skills, and preferences. For a first triage, prepare
+a short role-relevant excerpt instead of sharing the whole file by default.
 
 Do the same for `user_data/target_roles.md` with your role, location, and
 deal-breaker preferences.
+
+The [AI Assistant Integration Guide](AI-ASSISTANT-INTEGRATION.md) shows what to
+share in a browser chat and what to check before granting a workspace-aware
+assistant access to local files.
 
 ### Step 2: Find a Job Posting
 
@@ -181,7 +204,9 @@ Copy a job posting that interests you. You can use:
 1. Open `modes/01_JOB_TRIAGE.md`.
 2. Copy the entire file.
 3. Paste it into your AI assistant.
-4. Add:
+4. Add a short, role-relevant profile excerpt. Do not include contact details
+   unless they are needed for the task.
+5. Add:
 
    ```text
    Here is the job posting I want to evaluate:
@@ -189,7 +214,7 @@ Copy a job posting that interests you. You can use:
    [paste the posting here]
    ```
 
-5. The AI returns a structured evaluation with:
+6. The AI returns a structured evaluation with:
    - fit score
    - risks (ghost, exploitation, chaos)
    - compensation signal
@@ -382,6 +407,12 @@ npx markdownlint-cli2 "**/*.md" "#**/node_modules/**"
 Your personal data lives in `user_data/`, `inbox/`, `runs/`, `outputs/`, and
 `exports/`. These directories are gitignored by default. Never commit real
 personal information to the repository.
+
+The framework itself does not send these files to an AI provider. If you paste
+or upload content to an AI assistant, that selected content is sent to the
+provider under its own terms. A local file path alone does not make a browser
+chat able to read the file. Use the [AI Assistant Integration Guide](AI-ASSISTANT-INTEGRATION.md)
+to choose what to share and review your provider settings separately.
 
 If you want to back up your data, copy the directories above to a private
 location outside the repository.

--- a/docs/getting-started/QUICKSTART-30MIN.md
+++ b/docs/getting-started/QUICKSTART-30MIN.md
@@ -1,0 +1,71 @@
+# 30-Minute Quickstart
+
+This guide gets you from a ready local workspace to one documented job triage.
+The 30-minute path starts after base setup is complete. Installation time and
+optional LaTeX or DOCX tools are outside this estimate.
+
+## Before You Start
+
+1. Clone the repository and run the setup path in the [README](../../README.md).
+2. Confirm that `user_data/` and `inbox/jobs/` exist.
+3. Choose an AI sharing path in the
+   [AI Assistant Integration Guide](AI-ASSISTANT-INTEGRATION.md).
+
+If you only want to learn the workflow, use the fictitious files in `fixtures/`
+and do not add personal information yet.
+
+## 0-5 Minutes: Set Your Direction
+
+Open these local files in an editor:
+
+- `user_data/career_profile.md`
+- `user_data/target_roles.md`
+
+Replace only the most important placeholders: target roles, core skills, work
+preferences, and deal-breakers. For this first run, prepare a short excerpt
+that relates to the role you will evaluate. Keep contact details and unrelated
+history out of the assistant by default.
+
+## 5-10 Minutes: Pick One Posting
+
+Choose one public job posting, or rehearse with
+[`fixtures/sample-job-posting.md`](../../fixtures/sample-job-posting.md). Keep
+the source URL with the posting so you can revisit the evidence later.
+
+## 10-22 Minutes: Run the Triage
+
+1. Open [`modes/01_JOB_TRIAGE.md`](../../modes/01_JOB_TRIAGE.md).
+2. Paste the entire mode into your AI assistant.
+3. Add your narrow profile excerpt.
+4. Paste the job posting.
+5. Ask for the structured result required by the mode.
+
+Use the prompt shape in the [AI Assistant Integration Guide](AI-ASSISTANT-INTEGRATION.md)
+if you want a copy-ready starting point. The assistant should mark missing
+evidence as `Unknown`; do not fill gaps with guesses.
+
+## 22-30 Minutes: Save the Result Locally
+
+Create a Markdown record under `inbox/jobs/` with a clear date, company, and
+role title in its filename. Use the structure in
+[`fixtures/sample-triage-run.md`](../../fixtures/sample-triage-run.md) as a
+reference, then keep the original posting URL and the evaluation result in the
+record.
+
+Before moving a role forward, run the read-only checks in
+[Workflow Guards](WORKFLOW_GUARDS.md). They can identify duplicate records,
+missing lifecycle fields, and eligibility questions, but they never submit an
+application or change a record for you.
+
+## You Are Ready for the Next Step
+
+At this point you have one documented triage and a repeatable process. Continue
+with [Getting Started](GETTING_STARTED.md) to tailor a CV, export documents, or
+use the local dashboard.
+
+## If Something Is Missing
+
+- Setup issue: read [Setup and Verification](../setup-and-verification.md).
+- Unsure what to share with an AI assistant: return to the
+  [AI Assistant Integration Guide](AI-ASSISTANT-INTEGRATION.md).
+- Need a safe practice run: use the files in `fixtures/` first.

--- a/templates/user-data-skeleton/README.md
+++ b/templates/user-data-skeleton/README.md
@@ -3,15 +3,22 @@
 This directory contains YOUR personal career data. It is gitignored by default
 and should never be committed to a shared repository.
 
-## Files to Create
+## Starter Files
 
 | File | Purpose |
 | --- | --- |
 | `career_profile.md` | Your work history, education, contact info |
 | `target_roles.md` | What you're looking for, deal-breakers |
 | `skill_matrix_summary.md` | Honest self-assessment of skills |
+
+## Optional Working Files
+
+Add these files only when they are useful for your workflow:
+
+| File | Purpose |
+| --- | --- |
 | `achievement_inventory.md` | Quantified achievements for CV bullets |
-| `document_style_rules.md` | Personal formatting/tone preferences |
+| `document_style_rules.md` | Personal formatting and tone preferences |
 
 ## Principles
 

--- a/tests/test_documentation_contract.py
+++ b/tests/test_documentation_contract.py
@@ -44,3 +44,31 @@ def test_docx_reference_path_matches_validator_contract() -> None:
         assert "exports/cv-reference.docx" in content
         assert "templates/cv-reference.docx" not in content
         assert "exports/cv-variants-2026-06-21" not in content
+
+
+def test_onboarding_paths_make_ai_data_boundary_explicit() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    getting_started = (ROOT / "docs" / "getting-started" / "GETTING_STARTED.md").read_text(
+        encoding="utf-8"
+    )
+    template_readme = (ROOT / "templates" / "user-data-skeleton" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    assistant_guide = (
+        ROOT / "docs" / "getting-started" / "AI-ASSISTANT-INTEGRATION.md"
+    ).read_text(encoding="utf-8")
+    quickstart = (ROOT / "docs" / "getting-started" / "QUICKSTART-30MIN.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "docs/getting-started/QUICKSTART-30MIN.md" in readme
+    assert "docs/getting-started/AI-ASSISTANT-INTEGRATION.md" in readme
+    assert "- `templates/`" in readme
+    assert "## Advanced: Browser Extension" in readme
+    assert "[AI Assistant Integration Guide](AI-ASSISTANT-INTEGRATION.md)" in getting_started
+    assert "[30-Minute Quickstart](QUICKSTART-30MIN.md)" in getting_started
+    assert "The framework does not send your files to an AI provider." in assistant_guide
+    assert "Do not assume that a browser-based AI chat can read a local file path." in assistant_guide
+    assert "The 30-minute path starts after base setup is complete." in quickstart
+    assert "## Starter Files" in template_readme
+    assert "## Optional Working Files" in template_readme


### PR DESCRIPTION
## Summary
- add a portable AI-assistant integration guide with explicit data-sharing boundaries
- add a setup-excluded 30-minute first-triage quickstart
- align README, detailed onboarding, and starter-file inventory
- lock the user-facing privacy wording with a documentation contract test

## Local validation
- `60 passed` Python tests and dashboard smoke
- Ruff, Markdown lint, PII, secret, brand, language, license, and extension checks PASS

## Boundary
- documentation and test changes only; no dashboard, application automation, personal data, or release/tag changes