### PR TITLE
fix: require upgrade guidance in release notes

### DIFF
--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -1,0 +1,22 @@
+name: Release policy
+
+on:
+  release:
+    types: [published, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  release-notes:
+    name: Verify release notes upgrade link
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 scripts/check_release_notes_upgrade_link.py --event "$GITHUB_EVENT_PATH"
+        name: Require the current upgrade procedure in release notes

--- a/.github/workflows/setup-audit.yml
+++ b/.github/workflows/setup-audit.yml
@@ -24,9 +24,13 @@ jobs:
       - run: shellcheck --version
       - run: bash -n scripts/setup.sh
       - run: shellcheck scripts/setup.sh
+      - run: bash -n scripts/upgrade.sh
+      - run: shellcheck scripts/upgrade.sh
       - run: python3 -m unittest discover -s tests -v
       - run: ./scripts/setup.sh --check-only
       - run: ./scripts/setup.sh
+      - run: ./scripts/upgrade.sh v0.2.0
+        name: Verify lossless upgrade script
 
   windows:
     name: Windows setup contract
@@ -43,3 +47,6 @@ jobs:
         run: scripts\setup.bat --check-only
       - shell: cmd
         run: scripts\setup.bat
+      - shell: cmd
+        run: scripts\upgrade.bat v0.2.0
+        name: Verify lossless upgrade script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ Edition.
 
 ### Upgrade Safety
 
-- Added a data-preserving upgrade guide for direct clones and forks, including
-  a separate-clone test path, external workspace support and safe rollback.
+- Added `upgrade.sh` and `upgrade.bat` for data-preserving updates. They create
+  a dated backup, a separate tagged workspace, and copy personal records
+  without changing the original clone or fork.
+- Added a one-time bootstrap path for users upgrading from `v0.2.0` or earlier,
+  where the upgrade scripts were not yet present.
 - Every GitHub release note now links to the current upgrade procedure. A
   release-policy workflow verifies that link after publishing or editing a
   release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,20 @@
 This file records user-visible changes to Job Search Workflow Community
 Edition.
 
+## [0.2.1] - 2026-08-20
+
+### Upgrade Safety
+
+- Added a data-preserving upgrade guide for direct clones and forks, including
+  a separate-clone test path, external workspace support and safe rollback.
+- Every GitHub release note now links to the current upgrade procedure. A
+  release-policy workflow verifies that link after publishing or editing a
+  release.
+
 ## [0.2.0] - 2026-08-20
+
+For upgrade instructions, see
+[Upgrade Safely](docs/UPGRADING.md).
 
 ### Stable Release Additions
 

--- a/PUBLISH_CHECKLIST.md
+++ b/PUBLISH_CHECKLIST.md
@@ -15,6 +15,7 @@ own additional checklist in `PUBLISH_CHECKLIST_EXTENSION.md`.
 - [ ] Start the GitHub release body from `docs/release-notes-template.md` and
   retain its direct link to
   `https://github.com/rcnsnr/job-search-workflow/blob/main/docs/UPGRADING.md`.
+  State the exact `upgrade.sh` and `upgrade.bat` command for the release tag.
   The release-policy workflow must pass after publication; a release without
   that link is not verified.
 - [ ] Write release notes that state the source-only scope and do not claim a
@@ -39,6 +40,9 @@ own additional checklist in `PUBLISH_CHECKLIST_EXTENSION.md`.
   passes.
 - [ ] `python3 scripts/check_sample_cv_fixture_coverage.py --base origin/main`
   passes.
+- [ ] Run the platform-specific lossless upgrade script against the previous
+  release tag, or rely on the current-main Setup Audit where Linux and Windows
+  contracts run `upgrade.sh` and `upgrade.bat` against that tag.
 - [ ] If dashboard visuals changed, refresh all five stable files under
   `assets/screenshots/` and run
   `python3 scripts/check_dashboard_screenshot_coverage.py --base origin/main`.

--- a/PUBLISH_CHECKLIST.md
+++ b/PUBLISH_CHECKLIST.md
@@ -12,6 +12,11 @@ own additional checklist in `PUBLISH_CHECKLIST_EXTENSION.md`.
 - [ ] Choose an unused semantic version and update `pyproject.toml`,
   `dashboard/server.py`, and `CHANGELOG.md` together.
 - [ ] Confirm the release target is the current protected `main` commit.
+- [ ] Start the GitHub release body from `docs/release-notes-template.md` and
+  retain its direct link to
+  `https://github.com/rcnsnr/job-search-workflow/blob/main/docs/UPGRADING.md`.
+  The release-policy workflow must pass after publication; a release without
+  that link is not verified.
 - [ ] Write release notes that state the source-only scope and do not claim a
   hosted service, package-store publication, or commercial-use grant.
 
@@ -69,6 +74,8 @@ own additional checklist in `PUBLISH_CHECKLIST_EXTENSION.md`.
 
 - [ ] Confirm the tag and release resolve to the intended commit.
 - [ ] Confirm the release is not marked draft or prerelease.
+- [ ] Confirm the `Release policy / Verify release notes upgrade link` workflow
+  passes for the published release.
 - [ ] Confirm no new open release-blocking pull request or issue was created.
 - [ ] Record the release URL, commit, checks, and remaining non-release risks
   in the canonical private WP receipt.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 > 1.0.0. Commercial use is not granted by this repository. See
 > [Commercial Use and SaaS Boundary](COMMERCIAL_USE.md).
 
-See the [Changelog](CHANGELOG.md) for the current release notes.
+See the [Changelog](CHANGELOG.md) for the current release notes and
+[Upgrade Safely](docs/UPGRADING.md) before updating an existing clone or fork.
 Report vulnerabilities through the private-first process in
 [Security Policy](SECURITY.md).
 
@@ -52,6 +53,7 @@ Read the [Setup and Verification Guide](docs/setup-and-verification.md) for the 
 | First end-to-end workflow | [Getting Started](docs/getting-started/GETTING_STARTED.md) |
 | Use an AI assistant safely | [AI Assistant Integration Guide](docs/getting-started/AI-ASSISTANT-INTEGRATION.md) |
 | Setup and supported environments | [Setup and Verification](docs/setup-and-verification.md) |
+| Upgrade an existing clone or fork | [Upgrade Safely](docs/UPGRADING.md) |
 | Read-only record checks | [Workflow Guards](docs/getting-started/WORKFLOW_GUARDS.md) |
 | Public job-source discovery | [Source Discovery Operations](docs/runbooks/source-discovery-operations.md) |
 | Browser extension install | [Extension Install](docs/runbooks/browser-extension-install.md) |

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -468,7 +468,7 @@ def compute_stage_counts(cards: list[JobCard]) -> dict[str, int]:
 app = FastAPI(
     title=PRODUCT_NAME,
     description="Local-first dashboard for job search pipeline tracking.",
-    version="0.2.0",
+    version="0.2.1",
 )
 
 templates = Jinja2Templates(directory=str(PACKAGE_ROOT / "templates"))

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,116 @@
+# Upgrade Safely
+
+Use this guide for every Job Search Workflow Community Edition update. It keeps
+your personal workspace separate from framework code so you can test a new
+release without overwriting career data.
+
+## What a Release Changes
+
+The framework code is versioned in Git. Your personal data lives in local,
+Git-ignored directories:
+
+- `user_data/`
+- `inbox/`
+- `exports/`
+- `outputs/`
+- `runs/`
+
+Before every upgrade, make a copy of the directories that exist. Do not assume
+a clean `git status` means that personal data is absent: Git intentionally does
+not show ignored files.
+
+Current Community Edition releases do not run a database migration or write to
+these directories. The dashboard is read-only. Still, keep a dated backup so
+you can return to the previous workspace without risk.
+
+## Recommended: Test a New Clone First
+
+This is the safest path for most users. Keep the old folder unchanged until the
+new dashboard shows the expected records.
+
+1. Close any running dashboard process.
+2. Back up the five personal directories listed above from your current clone.
+3. Clone the tagged release into a separate folder. Replace `vX.Y.Z` with the
+   release tag shown in the release notes.
+
+   ```bash
+   git clone --branch vX.Y.Z https://github.com/rcnsnr/job-search-workflow.git job-search-workflow-vX.Y.Z
+   cd job-search-workflow-vX.Y.Z
+   ./scripts/setup.sh --check-only
+   ./scripts/setup.sh
+   ```
+
+   On Windows Command Prompt, use `scripts\setup.bat --check-only` and then
+   `scripts\setup.bat`.
+
+4. Start the new dashboard against the old workspace. Replace the path with the
+   absolute path of your existing clone.
+
+   ```bash
+   JSW_WORKSPACE="/absolute/path/to/your-existing-workspace" python3 -m jsw dashboard
+   ```
+
+5. Check your jobs, profile and application documents in the browser. If they
+   look correct, you can use the new clone. Keep the old clone and backup until
+   you are comfortable with the update.
+
+For long-term separation, copy the five personal directories into a dedicated
+local folder outside every clone, then point the dashboard at that folder with
+`JSW_WORKSPACE`. Future code upgrades can then use fresh clones without moving
+your data.
+
+## Update an Unmodified Direct Clone
+
+Use this only when `git status --short` shows no tracked-code changes that you
+need to keep. Back up personal directories first.
+
+```bash
+git fetch origin --tags
+git switch main
+git pull --ff-only origin main
+git switch --detach vX.Y.Z
+./scripts/setup.sh --check-only
+./scripts/setup.sh
+PYTHONPATH=scripts python3 -m jsw smoke
+```
+
+`--ff-only` is deliberate: it stops instead of combining an unexpected local
+history with the public release. If it stops, use the recommended new-clone
+path rather than forcing a pull, rebase, or reset.
+
+## Update a Fork
+
+Fork owners should keep their fork remote as `origin` and add the public
+project as `upstream` once:
+
+```bash
+git remote add upstream https://github.com/rcnsnr/job-search-workflow.git
+git fetch upstream --tags
+git switch main
+git merge --ff-only upstream/main
+git push origin main
+git switch --detach vX.Y.Z
+```
+
+If the fast-forward merge stops because your fork has framework changes, do not
+force it. Create a separate upgrade branch from `upstream/main`, test it against
+your existing workspace, and merge your customizations deliberately.
+
+## Roll Back
+
+Your backup and old clone remain valid rollback points. To return the framework
+code to a prior known tag, switch the new clone to that tag. Your ignored
+personal directories are not changed by this command.
+
+```bash
+git switch --detach vPREVIOUS.VERSION
+```
+
+Never use `git reset --hard` as an upgrade step. It is unnecessary for the
+supported update paths and can discard tracked local changes.
+
+## Release Notes Rule
+
+Every GitHub release note links to this current guide. Start release text from
+the [release-notes template](release-notes-template.md); the release-policy
+workflow verifies the public link after a release is published or edited.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -23,78 +23,69 @@ Current Community Edition releases do not run a database migration or write to
 these directories. The dashboard is read-only. Still, keep a dated backup so
 you can return to the previous workspace without risk.
 
-## Recommended: Test a New Clone First
+## Recommended: Run the Upgrade Script
 
-This is the safest path for most users. Keep the old folder unchanged until the
-new dashboard shows the expected records.
-
-1. Close any running dashboard process.
-2. Back up the five personal directories listed above from your current clone.
-3. Clone the tagged release into a separate folder. Replace `vX.Y.Z` with the
-   release tag shown in the release notes.
-
-   ```bash
-   git clone --branch vX.Y.Z https://github.com/rcnsnr/job-search-workflow.git job-search-workflow-vX.Y.Z
-   cd job-search-workflow-vX.Y.Z
-   ./scripts/setup.sh --check-only
-   ./scripts/setup.sh
-   ```
-
-   On Windows Command Prompt, use `scripts\setup.bat --check-only` and then
-   `scripts\setup.bat`.
-
-4. Start the new dashboard against the old workspace. Replace the path with the
-   absolute path of your existing clone.
-
-   ```bash
-   JSW_WORKSPACE="/absolute/path/to/your-existing-workspace" python3 -m jsw dashboard
-   ```
-
-5. Check your jobs, profile and application documents in the browser. If they
-   look correct, you can use the new clone. Keep the old clone and backup until
-   you are comfortable with the update.
-
-For long-term separation, copy the five personal directories into a dedicated
-local folder outside every clone, then point the dashboard at that folder with
-`JSW_WORKSPACE`. Future code upgrades can then use fresh clones without moving
-your data.
-
-## Update an Unmodified Direct Clone
-
-Use this only when `git status --short` shows no tracked-code changes that you
-need to keep. Back up personal directories first.
+This is the supported path for direct clones and forks. Close any running
+dashboard process, open a terminal in your current clone, and run the exact tag
+named in the release notes:
 
 ```bash
-git fetch origin --tags
-git switch main
-git pull --ff-only origin main
-git switch --detach vX.Y.Z
-./scripts/setup.sh --check-only
-./scripts/setup.sh
-PYTHONPATH=scripts python3 -m jsw smoke
+./scripts/upgrade.sh vX.Y.Z
 ```
 
-`--ff-only` is deliberate: it stops instead of combining an unexpected local
-history with the public release. If it stops, use the recommended new-clone
-path rather than forcing a pull, rebase, or reset.
+On Windows Command Prompt:
 
-## Update a Fork
+```bat
+scripts\upgrade.bat vX.Y.Z
+```
 
-Fork owners should keep their fork remote as `origin` and add the public
-project as `upstream` once:
+The script does four things in this order:
+
+1. Creates a dated backup outside the current clone.
+2. Clones the requested release into a separate sibling folder.
+3. Copies `user_data/`, `inbox/`, `exports/`, `outputs/` and `runs/` into that
+   new folder.
+4. Checks the new release prerequisites without changing the original
+   workspace.
+
+It never runs `git pull`, `git reset`, `git rebase`, or a delete command against
+your existing workspace. If the tag, backup path, copy, clone, or prerequisite
+check fails, it stops and leaves the original workspace in place.
+
+You may omit the version to use the latest published stable GitHub release, but
+using the exact tag from release notes is more reproducible:
 
 ```bash
-git remote add upstream https://github.com/rcnsnr/job-search-workflow.git
-git fetch upstream --tags
-git switch main
-git merge --ff-only upstream/main
-git push origin main
-git switch --detach vX.Y.Z
+./scripts/upgrade.sh
 ```
 
-If the fast-forward merge stops because your fork has framework changes, do not
-force it. Create a separate upgrade branch from `upstream/main`, test it against
-your existing workspace, and merge your customizations deliberately.
+After a successful run, open the printed new workspace path, install the local
+dashboard dependency if needed, and start the dashboard there. Keep the old
+clone and dated backup until you have checked your records.
+
+### One-Time Bootstrap for v0.2.0 and Earlier
+
+Older releases do not include the upgrade scripts. Download or clone the
+`v0.2.1` source into a temporary folder, then point its script at your current
+workspace. This first bootstrap does not alter the old workspace:
+
+```bash
+git clone --branch v0.2.1 https://github.com/rcnsnr/job-search-workflow.git /tmp/jsw-upgrade-v0.2.1
+/tmp/jsw-upgrade-v0.2.1/scripts/upgrade.sh v0.2.1 --source /absolute/path/to/your-current-workspace
+```
+
+On Windows, clone `v0.2.1` into a temporary folder and run
+`scripts\upgrade.bat v0.2.1 --source C:\path\to\your-current-workspace` from
+that temporary clone. From `v0.2.1` onward, the normal one-command path is
+available inside every workspace.
+
+## Forks and Local Customizations
+
+The upgrade scripts always clone the official tagged Community Edition release
+into a new sibling folder. They do not merge, rebase, or alter your fork's Git
+history, so the same command is safe when your fork or clone has local framework
+customizations. Compare and transfer any custom code deliberately after the new
+workspace has been checked.
 
 ## Roll Back
 
@@ -107,7 +98,7 @@ git switch --detach vPREVIOUS.VERSION
 ```
 
 Never use `git reset --hard` as an upgrade step. It is unnecessary for the
-supported update paths and can discard tracked local changes.
+supported update script and can discard tracked local changes.
 
 ## Release Notes Rule
 

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -10,7 +10,9 @@ and keep the upgrade link unchanged so users always reach the current procedure.
 
 ## Upgrade safely
 
-Follow the [current upgrade procedure](https://github.com/rcnsnr/job-search-workflow/blob/main/docs/UPGRADING.md) before updating an existing clone or fork.
+Run `./scripts/upgrade.sh vX.Y.Z` on Linux/macOS or `scripts\upgrade.bat vX.Y.Z`
+on Windows. The scripts create a backup and a separate release workspace before
+copying personal data. Read the [current upgrade procedure](https://github.com/rcnsnr/job-search-workflow/blob/main/docs/UPGRADING.md) for the full behavior.
 
 ## Validation
 

--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -1,0 +1,28 @@
+# Release Notes Template
+
+Copy this template into every GitHub release body. Replace the bracketed text
+and keep the upgrade link unchanged so users always reach the current procedure.
+
+```md
+## Highlights
+
+- [User-visible change]
+
+## Upgrade safely
+
+Follow the [current upgrade procedure](https://github.com/rcnsnr/job-search-workflow/blob/main/docs/UPGRADING.md) before updating an existing clone or fork.
+
+## Validation
+
+- [Checks run for this release]
+
+## Scope and license
+
+This is a source-only GitHub release. No private workspace data is included.
+Community Edition is source-available for noncommercial use under PolyForm
+Noncommercial 1.0.0; commercial use requires a separate written agreement.
+```
+
+The release-policy workflow verifies the exact upgrade-guide URL whenever a
+GitHub release is published or edited. A failed check means the release is not
+verified until its notes are corrected and the workflow passes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "job-search-workflow"
-version = "0.2.0"
+version = "0.2.1"
 description = "AI-assisted, local-first job search workflow framework — triage, scoring, application tracking"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/check_dashboard_screenshot_coverage.py
+++ b/scripts/check_dashboard_screenshot_coverage.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 from pathlib import Path
 
@@ -22,18 +23,36 @@ VISUAL_SOURCE_PREFIXES = (
     "dashboard/templates/",
 )
 VISUAL_SOURCE_FILES = {"dashboard/server.py"}
+SERVER_VERSION_CHANGE = re.compile(r'^[+-]\s*version="[^"]+",$')
 
 
-def has_visual_dashboard_change(changed_paths: set[str]) -> bool:
+def server_diff_is_metadata_only(diff: str) -> bool:
+    """Allow a FastAPI version-only bump without requiring new screenshots."""
+    changed_lines = [
+        line
+        for line in diff.splitlines()
+        if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+    ]
+    return bool(changed_lines) and all(SERVER_VERSION_CHANGE.fullmatch(line) for line in changed_lines)
+
+
+def has_visual_dashboard_change(
+    changed_paths: set[str], *, server_change_is_metadata_only: bool = False
+) -> bool:
+    """Return whether changed paths can alter dashboard screenshots."""
     return any(
-        path in VISUAL_SOURCE_FILES
+        (path in VISUAL_SOURCE_FILES and not server_change_is_metadata_only)
         or path.startswith(VISUAL_SOURCE_PREFIXES)
         for path in changed_paths
     )
 
 
-def missing_screenshot_updates(changed_paths: set[str]) -> set[str]:
-    if not has_visual_dashboard_change(changed_paths):
+def missing_screenshot_updates(
+    changed_paths: set[str], *, server_change_is_metadata_only: bool = False
+) -> set[str]:
+    if not has_visual_dashboard_change(
+        changed_paths, server_change_is_metadata_only=server_change_is_metadata_only
+    ):
         return set()
     if CAPTURE_RECEIPT in changed_paths:
         return set()
@@ -49,6 +68,18 @@ def changed_paths_since(base_ref: str) -> set[str]:
         text=True,
     )
     return {line for line in result.stdout.splitlines() if line}
+
+
+def server_diff_since(base_ref: str) -> str:
+    """Return the zero-context diff for the dashboard server."""
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", f"{base_ref}...HEAD", "--", "dashboard/server.py"],
+        check=True,
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
 
 
 def main() -> int:
@@ -74,7 +105,13 @@ def main() -> int:
             print(error.stderr.strip())
         return 2
 
-    missing = missing_screenshot_updates(changed_paths)
+    metadata_only = (
+        "dashboard/server.py" in changed_paths
+        and server_diff_is_metadata_only(server_diff_since(args.base))
+    )
+    missing = missing_screenshot_updates(
+        changed_paths, server_change_is_metadata_only=metadata_only
+    )
     if not missing:
         print("PASS dashboard screenshot coverage")
         return 0

--- a/scripts/check_release_notes_upgrade_link.py
+++ b/scripts/check_release_notes_upgrade_link.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Verify that published GitHub release notes link to the upgrade guide."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+UPGRADE_GUIDE_URL = (
+    "https://github.com/rcnsnr/job-search-workflow/blob/main/docs/UPGRADING.md"
+)
+
+
+def has_upgrade_link(release_notes: str) -> bool:
+    """Return whether release notes contain the canonical upgrade-guide URL."""
+    return UPGRADE_GUIDE_URL in release_notes
+
+
+def release_body_from_event(event_path: Path) -> str:
+    """Read the release body from a GitHub release event payload."""
+    event = json.loads(event_path.read_text(encoding="utf-8"))
+    release = event.get("release")
+    if not isinstance(release, dict):
+        raise ValueError("GitHub event payload does not contain a release object")
+    body = release.get("body", "")
+    if not isinstance(body, str):
+        raise ValueError("GitHub release body is not text")
+    return body
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Require a canonical upgrade-guide link in GitHub release notes."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--body", help="Release-note text to validate.")
+    source.add_argument("--event", type=Path, help="GitHub release event JSON payload.")
+    args = parser.parse_args()
+
+    try:
+        release_notes = args.body if args.body is not None else release_body_from_event(args.event)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"FAIL release notes upgrade link: {error}")
+        return 2
+
+    if not has_upgrade_link(release_notes):
+        print("FAIL release notes upgrade link: missing canonical upgrade-guide URL")
+        print(f"Expected: {UPGRADE_GUIDE_URL}")
+        return 1
+
+    print("PASS release notes upgrade link")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/upgrade.bat
+++ b/scripts/upgrade.bat
@@ -1,0 +1,117 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "UPSTREAM_URL=https://github.com/rcnsnr/job-search-workflow.git"
+set "UPSTREAM_API=https://api.github.com/repos/rcnsnr/job-search-workflow/releases/latest"
+set "SCRIPT_DIR=%~dp0"
+for %%I in ("%SCRIPT_DIR%..") do set "DEFAULT_SOURCE_ROOT=%%~fI"
+set "SOURCE_ROOT=%DEFAULT_SOURCE_ROOT%"
+set "TAG="
+
+:parse_args
+if "%~1"=="" goto args_done
+if "%~1"=="--help" goto help
+if "%~1"=="-h" goto help
+if "%~1"=="--source" (
+    if "%~2"=="" (
+        echo --source requires a workspace path. >&2
+        goto fail
+    )
+    set "SOURCE_ROOT=%~2"
+    shift
+    shift
+    goto parse_args
+)
+if not "%TAG%"=="" goto invalid_args
+set "TAG=%~1"
+shift
+goto parse_args
+
+:args_done
+for %%I in ("%SOURCE_ROOT%") do set "SOURCE_ROOT=%%~fI"
+for %%I in ("%SOURCE_ROOT%\..") do set "PARENT_DIR=%%~fI"
+
+if "%TAG%"=="" (
+    for /f "delims=" %%a in ('python -c "import json, urllib.request; print(json.load(urllib.request.urlopen('%UPSTREAM_API%', timeout=20))['tag_name'])"') do set "TAG=%%a"
+    if errorlevel 1 goto fail
+) else (
+    set "TAG=%~1"
+)
+
+python -c "import re, sys; sys.exit(0 if re.fullmatch(r'v\d+\.\d+\.\d+', sys.argv[1]) else 1)" "%TAG%"
+if errorlevel 1 (
+    echo Release tag must use vX.Y.Z format. >&2
+    goto fail
+)
+
+if not exist "%SOURCE_ROOT%\README.md" (
+    echo Repository root could not be verified. >&2
+    goto fail
+)
+if not exist "%SOURCE_ROOT%\.git" (
+    echo Run this script from a Git clone. >&2
+    goto fail
+)
+
+for /f "delims=" %%a in ('python -c "from datetime import datetime; print(datetime.now().strftime('%%Y%%m%%d-%%H%%M%%S'))"') do set "STAMP=%%a"
+set "BACKUP_DIR=%PARENT_DIR%\job-search-workflow-backups\%STAMP%-%TAG%"
+set "RELEASE_DIR=%PARENT_DIR%\job-search-workflow-%TAG%"
+
+if exist "%BACKUP_DIR%" (
+    echo Backup path already exists: %BACKUP_DIR% >&2
+    goto fail
+)
+if exist "%RELEASE_DIR%" (
+    echo Release path already exists: %RELEASE_DIR% >&2
+    goto fail
+)
+
+mkdir "%BACKUP_DIR%"
+if errorlevel 1 goto fail
+echo Creating backup at: %BACKUP_DIR%
+call :copy_personal "%SOURCE_ROOT%" "%BACKUP_DIR%"
+if errorlevel 1 goto fail
+
+echo Cloning %TAG% into: %RELEASE_DIR%
+git clone --branch "%TAG%" --single-branch "%UPSTREAM_URL%" "%RELEASE_DIR%"
+if errorlevel 1 goto fail
+
+echo Copying personal data into the new release workspace...
+call :copy_personal "%SOURCE_ROOT%" "%RELEASE_DIR%"
+if errorlevel 1 goto fail
+
+echo Checking the new release prerequisites...
+call "%RELEASE_DIR%\scripts\setup.bat" --check-only
+if errorlevel 1 goto fail
+
+echo PASS upgrade
+echo Backup: %BACKUP_DIR%
+echo New workspace: %RELEASE_DIR%
+echo Original workspace: %SOURCE_ROOT%
+echo.
+echo Your original workspace was not changed. To start the new dashboard:
+echo   cd /d "%RELEASE_DIR%"
+echo   python -m pip install -e ".[dashboard]"
+echo   python -m jsw dashboard
+exit /b 0
+
+:copy_personal
+for %%D in (user_data inbox exports outputs runs) do (
+    if exist "%~1\%%D" (
+        xcopy "%~1\%%D" "%~2\%%D\" /E /I /H /K /Y >nul
+        if errorlevel 1 exit /b 1
+        echo Copied personal directory: %%D
+    )
+)
+exit /b 0
+
+:help
+echo Usage: %~nx0 [vX.Y.Z] [--source C:\path\to\current-workspace]
+echo Creates a backup and a separate release clone without changing this workspace.
+exit /b 0
+
+:invalid_args
+echo Only one optional release tag is accepted. >&2
+
+:fail
+exit /b 1

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Create a lossless release upgrade beside the current workspace.
+# Usage: ./scripts/upgrade.sh [vX.Y.Z] [--source /path/to/current-workspace]
+
+set -euo pipefail
+
+UPSTREAM_URL="https://github.com/rcnsnr/job-search-workflow.git"
+UPSTREAM_API="https://api.github.com/repos/rcnsnr/job-search-workflow/releases/latest"
+PERSONAL_DIRECTORIES=(user_data inbox exports outputs runs)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_SOURCE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+fail() {
+    echo "[ERROR] $*" >&2
+    exit 1
+}
+
+usage() {
+    echo "Usage: $0 [vX.Y.Z] [--source /path/to/current-workspace]"
+    echo "Creates a backup and a separate release clone without changing this workspace."
+}
+
+latest_release_tag() {
+    python3 - "$UPSTREAM_API" <<'PY'
+import json
+import sys
+from urllib.request import urlopen
+
+with urlopen(sys.argv[1], timeout=20) as response:
+    payload = json.load(response)
+tag = payload.get("tag_name")
+if not isinstance(tag, str):
+    raise SystemExit("GitHub did not return a release tag")
+print(tag)
+PY
+}
+
+validate_tag() {
+    [[ "$1" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+copy_personal_directories() {
+    local source="$1"
+    local destination="$2"
+    local directory
+
+    for directory in "${PERSONAL_DIRECTORIES[@]}"; do
+        if [[ -e "$source/$directory" ]]; then
+            cp -a "$source/$directory" "$destination/$directory"
+            echo "Copied personal directory: $directory"
+        fi
+    done
+}
+
+TAG=""
+SOURCE_ROOT="$DEFAULT_SOURCE_ROOT"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source)
+            [[ $# -ge 2 ]] || fail "--source requires a workspace path."
+            SOURCE_ROOT="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        v*)
+            [[ -z "$TAG" ]] || fail "Only one release tag is accepted."
+            TAG="$1"
+            shift
+            ;;
+        *) fail "Unknown argument: $1" ;;
+    esac
+done
+
+SOURCE_ROOT="$(cd "$SOURCE_ROOT" && pwd)"
+PARENT_DIR="$(cd "$SOURCE_ROOT/.." && pwd)"
+if [[ -z "$TAG" ]]; then
+    TAG="$(latest_release_tag)"
+fi
+
+[[ -f "$SOURCE_ROOT/README.md" ]] || fail "Repository root could not be verified."
+[[ -d "$SOURCE_ROOT/.git" ]] || fail "Run this script from a Git clone."
+validate_tag "$TAG" || fail "Release tag must use vX.Y.Z format; received: $TAG"
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="$PARENT_DIR/job-search-workflow-backups/$STAMP-$TAG"
+RELEASE_DIR="$PARENT_DIR/job-search-workflow-$TAG"
+
+[[ ! -e "$BACKUP_DIR" ]] || fail "Backup path already exists: $BACKUP_DIR"
+[[ ! -e "$RELEASE_DIR" ]] || fail "Release path already exists: $RELEASE_DIR"
+
+mkdir -p "$BACKUP_DIR"
+echo "Creating backup at: $BACKUP_DIR"
+copy_personal_directories "$SOURCE_ROOT" "$BACKUP_DIR"
+
+echo "Cloning $TAG into: $RELEASE_DIR"
+git clone --branch "$TAG" --single-branch "$UPSTREAM_URL" "$RELEASE_DIR"
+
+echo "Copying personal data into the new release workspace..."
+copy_personal_directories "$SOURCE_ROOT" "$RELEASE_DIR"
+
+echo "Checking the new release prerequisites..."
+"$RELEASE_DIR/scripts/setup.sh" --check-only
+
+cat <<EOF
+PASS upgrade
+Backup: $BACKUP_DIR
+New workspace: $RELEASE_DIR
+Original workspace: $SOURCE_ROOT
+
+Your original workspace was not changed. To start the new dashboard:
+  cd "$RELEASE_DIR"
+  python3 -m pip install -e ".[dashboard]"
+  python3 -m jsw dashboard
+EOF

--- a/tests/test_dashboard_screenshot_coverage.py
+++ b/tests/test_dashboard_screenshot_coverage.py
@@ -29,6 +29,27 @@ def test_nonvisual_change_does_not_require_screenshot_refresh() -> None:
     assert coverage.missing_screenshot_updates({"README.md"}) == set()
 
 
+def test_fastapi_version_only_bump_does_not_require_screenshot_refresh() -> None:
+    version_only_diff = '-    version="0.2.0",\n+    version="0.2.1",\n'
+
+    assert coverage.server_diff_is_metadata_only(version_only_diff)
+    assert (
+        coverage.missing_screenshot_updates(
+            {"dashboard/server.py"}, server_change_is_metadata_only=True
+        )
+        == set()
+    )
+
+
+def test_dashboard_server_content_change_still_requires_screenshot_refresh() -> None:
+    content_diff = '-    description="Old copy",\n+    description="New copy",\n'
+
+    assert not coverage.server_diff_is_metadata_only(content_diff)
+    assert coverage.missing_screenshot_updates({"dashboard/server.py"}) == set(
+        coverage.STABLE_SCREENSHOTS
+    )
+
+
 def test_capture_receipt_covers_a_recheck_with_identical_pixels() -> None:
     changed_paths = {
         "dashboard/server.py",

--- a/tests/test_documentation_contract.py
+++ b/tests/test_documentation_contract.py
@@ -26,6 +26,26 @@ def test_local_markdown_links_resolve() -> None:
     assert missing == []
 
 
+def test_release_notes_always_link_to_the_current_upgrade_guide() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    checklist = (ROOT / "PUBLISH_CHECKLIST.md").read_text(encoding="utf-8")
+    template = (ROOT / "docs" / "release-notes-template.md").read_text(encoding="utf-8")
+    workflow = (ROOT / ".github" / "workflows" / "release-policy.yml").read_text(
+        encoding="utf-8"
+    )
+
+    guide_url = "https://github.com/rcnsnr/job-search-workflow/blob/main/docs/UPGRADING.md"
+    assert (ROOT / "docs" / "UPGRADING.md").is_file()
+    assert "docs/UPGRADING.md" in readme
+    assert "docs/UPGRADING.md" in changelog
+    assert guide_url in checklist
+    assert guide_url in template
+    assert "types: [published, edited]" in workflow
+    assert "ref: main" in workflow
+    assert "scripts/check_release_notes_upgrade_link.py" in workflow
+
+
 def test_setup_guide_matches_current_workflow_and_node_contract() -> None:
     guide = (ROOT / "docs" / "setup-and-verification.md").read_text(encoding="utf-8")
 

--- a/tests/test_documentation_contract.py
+++ b/tests/test_documentation_contract.py
@@ -39,6 +39,8 @@ def test_release_notes_always_link_to_the_current_upgrade_guide() -> None:
     assert (ROOT / "docs" / "UPGRADING.md").is_file()
     assert "docs/UPGRADING.md" in readme
     assert "docs/UPGRADING.md" in changelog
+    assert "upgrade.sh" in checklist
+    assert "upgrade.bat" in checklist
     assert guide_url in checklist
     assert guide_url in template
     assert "types: [published, edited]" in workflow

--- a/tests/test_release_notes_upgrade_link.py
+++ b/tests/test_release_notes_upgrade_link.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+
+from scripts.check_release_notes_upgrade_link import (
+    UPGRADE_GUIDE_URL,
+    has_upgrade_link,
+    release_body_from_event,
+)
+
+
+def test_release_notes_require_the_canonical_upgrade_link() -> None:
+    assert has_upgrade_link(f"Upgrade here: {UPGRADE_GUIDE_URL}")
+    assert not has_upgrade_link("No upgrade instructions are included.")
+
+
+def test_release_event_reader_returns_release_body(tmp_path) -> None:
+    event_path = tmp_path / "release.json"
+    event_path.write_text(json.dumps({"release": {"body": UPGRADE_GUIDE_URL}}), encoding="utf-8")
+
+    assert release_body_from_event(event_path) == UPGRADE_GUIDE_URL

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+UPGRADE_SH = SOURCE_ROOT / "scripts" / "upgrade.sh"
+UPGRADE_BAT = SOURCE_ROOT / "scripts" / "upgrade.bat"
+
+
+def make_upgrade_fixture() -> tuple[Path, Path, Path]:
+    root = Path(tempfile.mkdtemp(prefix="workflow-upgrade-"))
+    source = root / "current-workspace"
+    template = root / "release-template"
+    fake_bin = root / "fake-bin"
+
+    (source / "scripts").mkdir(parents=True)
+    (source / ".git").mkdir()
+    (source / "README.md").write_text("# Current workspace\n", encoding="utf-8")
+    (source / "user_data").mkdir()
+    (source / "user_data" / "profile.md").write_text("private profile\n", encoding="utf-8")
+    (source / "inbox" / "jobs").mkdir(parents=True)
+    (source / "inbox" / "jobs" / "role.md").write_text(encoding="utf-8", data="private job\n")
+    shutil.copy2(UPGRADE_SH, source / "scripts" / "upgrade.sh")
+    (source / "scripts" / "upgrade.sh").chmod(
+        (source / "scripts" / "upgrade.sh").stat().st_mode | stat.S_IXUSR
+    )
+
+    (template / "scripts").mkdir(parents=True)
+    (template / "README.md").write_text("# Release workspace\n", encoding="utf-8")
+    setup = template / "scripts" / "setup.sh"
+    setup.write_text("#!/usr/bin/env bash\necho PASS setup-check\n", encoding="utf-8")
+    setup.chmod(setup.stat().st_mode | stat.S_IXUSR)
+
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "if [[ $1 == clone ]]; then\n"
+        "  target=${@: -1}\n"
+        "  mkdir -p \"$target\"\n"
+        "  cp -a \"$FAKE_RELEASE_TEMPLATE/.\" \"$target/\"\n"
+        "  exit 0\n"
+        "fi\n"
+        "echo \"unexpected git invocation: $*\" >&2\n"
+        "exit 2\n",
+        encoding="utf-8",
+    )
+    fake_git.chmod(fake_git.stat().st_mode | stat.S_IXUSR)
+    return root, source, template
+
+
+def run_upgrade(source: Path, template: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment["PATH"] = f"{source.parent / 'fake-bin'}:{environment['PATH']}"
+    environment["FAKE_RELEASE_TEMPLATE"] = str(template)
+    return subprocess.run(
+        [str(source / "scripts" / "upgrade.sh"), *args],
+        cwd="/",
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def test_upgrade_script_preserves_source_and_copies_personal_data() -> None:
+    root, source, template = make_upgrade_fixture()
+    try:
+        result = run_upgrade(source, template, "v0.2.1")
+
+        assert result.returncode == 0, result.stderr
+        assert "PASS upgrade" in result.stdout
+        assert (source / "user_data" / "profile.md").read_text(encoding="utf-8") == "private profile\n"
+        release = root / "job-search-workflow-v0.2.1"
+        assert (release / "user_data" / "profile.md").read_text(encoding="utf-8") == "private profile\n"
+        assert (release / "inbox" / "jobs" / "role.md").read_text(encoding="utf-8") == "private job\n"
+        backups = list((root / "job-search-workflow-backups").glob("*-v0.2.1"))
+        assert len(backups) == 1
+        assert (backups[0] / "user_data" / "profile.md").exists()
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_upgrade_script_refuses_to_overwrite_an_existing_release_workspace() -> None:
+    root, source, template = make_upgrade_fixture()
+    try:
+        (root / "job-search-workflow-v0.2.1").mkdir()
+
+        result = run_upgrade(source, template, "v0.2.1")
+
+        assert result.returncode != 0
+        assert "Release path already exists" in result.stderr
+        assert (source / "user_data" / "profile.md").read_text(encoding="utf-8") == "private profile\n"
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_upgrade_script_accepts_a_source_override_for_bootstrapping() -> None:
+    root, source, template = make_upgrade_fixture()
+    try:
+        bootstrap = root / "bootstrap" / "scripts"
+        bootstrap.mkdir(parents=True)
+        shutil.copy2(UPGRADE_SH, bootstrap / "upgrade.sh")
+        (bootstrap / "upgrade.sh").chmod((bootstrap / "upgrade.sh").stat().st_mode | stat.S_IXUSR)
+
+        result = subprocess.run(
+            [str(bootstrap / "upgrade.sh"), "v0.2.1", "--source", str(source)],
+            cwd="/",
+            env={
+                **os.environ,
+                "PATH": f"{root / 'fake-bin'}:{os.environ['PATH']}",
+                "FAKE_RELEASE_TEMPLATE": str(template),
+            },
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert (root / "job-search-workflow-v0.2.1" / "user_data" / "profile.md").exists()
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_upgrade_scripts_exist_for_linux_macos_and_windows() -> None:
+    assert UPGRADE_SH.is_file()
+    assert UPGRADE_BAT.is_file()
+    assert "xcopy" in UPGRADE_BAT.read_text(encoding="utf-8").lower()


### PR DESCRIPTION
## Summary

- add data-preserving `upgrade.sh` and `upgrade.bat` commands for tagged releases
- create a dated backup and separate release workspace without changing the original clone or fork
- add a one-time v0.2.0 bootstrap path, a release-notes template, and release-policy verification
- verify the upgrade scripts in Linux and Windows Setup Audit

## Validation

- 77 Python tests passed, including isolated lossless-upgrade behavior tests
- real local upgrade replay against v0.2.0 passed
- 150 browser-extension tests passed
- Ruff, ShellCheck, Markdown, PII, secret, language, license, smoke, manifest, and high-severity dependency audit passed

## Policy Lock Receipt

- Decision Surface: public GitHub release notes and user upgrade path
- Classification: HARD_LOCK_REQUIRED
- Trigger: missing upgrade guidance can cause data-loss-risky user updates and false release readiness
- Enforcement Surface: release-policy workflow, documentation contract tests, upgrade behavior tests, and Linux/Windows Setup Audit
- Validator: `scripts/check_release_notes_upgrade_link.py`, `tests/test_upgrade.py`
- Override: no automatic override; correct the release notes or script behavior and rerun the owning workflow