### PR TITLE
fix: validate upgrade tags on Windows

### DIFF
--- a/scripts/upgrade.bat
+++ b/scripts/upgrade.bat
@@ -38,7 +38,8 @@ if "%TAG%"=="" (
     set "TAG=%~1"
 )
 
-python -c "import re, sys; sys.exit(0 if re.fullmatch(r'v\d+\.\d+\.\d+', sys.argv[1]) else 1)" "%TAG%"
+echo Requested release: %TAG%
+echo(%TAG%| findstr /r /x "v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*" >nul
 if errorlevel 1 (
     echo Release tag must use vX.Y.Z format. >&2
     goto fail

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -134,4 +134,7 @@ def test_upgrade_script_accepts_a_source_override_for_bootstrapping() -> None:
 def test_upgrade_scripts_exist_for_linux_macos_and_windows() -> None:
     assert UPGRADE_SH.is_file()
     assert UPGRADE_BAT.is_file()
-    assert "xcopy" in UPGRADE_BAT.read_text(encoding="utf-8").lower()
+    batch_script = UPGRADE_BAT.read_text(encoding="utf-8").lower()
+
+    assert "xcopy" in batch_script
+    assert "findstr /r /x" in batch_script


### PR DESCRIPTION
## Summary

- replace the Windows batch tag-validation expression that rejected valid semantic tags
- retain strict `vX.Y.Z` validation through the native Windows `findstr` command
- extend the upgrade-script contract test

## Validation

- 19 focused Python tests passed
- Ruff, Bash syntax, ShellCheck, and diff hygiene passed

## Root-Cause Receipt

- Failure: the Windows Setup Audit rejected `v0.2.0` before cloning
- Cause: the original Python regex invocation in `upgrade.bat` did not validate the passed tag under real CMD
- Fix: use the native Windows pattern check and verify it in the existing script contract test
- Regression gate: Windows Setup Audit runs `scripts\upgrade.bat v0.2.0`
