### PR TITLE
fix: preserve Windows upgrade arguments

### DIFF
--- a/scripts/upgrade.bat
+++ b/scripts/upgrade.bat
@@ -38,7 +38,8 @@ if "%TAG%"=="" (
     set "TAG=%~1"
 )
 
-python -c "import re, sys; sys.exit(0 if re.fullmatch(r'v\d+\.\d+\.\d+', sys.argv[1]) else 1)" "%TAG%"
+echo Requested release: %TAG%
+echo(%TAG%| findstr /r /x "v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*" >nul
 if errorlevel 1 (
     echo Release tag must use vX.Y.Z format. >&2
     goto fail

--- a/scripts/upgrade.bat
+++ b/scripts/upgrade.bat
@@ -6,26 +6,18 @@ set "UPSTREAM_API=https://api.github.com/repos/rcnsnr/job-search-workflow/releas
 set "SCRIPT_DIR=%~dp0"
 for %%I in ("%SCRIPT_DIR%..") do set "DEFAULT_SOURCE_ROOT=%%~fI"
 set "SOURCE_ROOT=%DEFAULT_SOURCE_ROOT%"
-set "TAG="
-
-:parse_args
-if "%~1"=="" goto args_done
-if "%~1"=="--help" goto help
-if "%~1"=="-h" goto help
-if "%~1"=="--source" (
-    if "%~2"=="" (
-        echo --source requires a workspace path. >&2
-        goto fail
-    )
-    set "SOURCE_ROOT=%~2"
-    shift
-    shift
-    goto parse_args
-)
-if not "%TAG%"=="" goto invalid_args
 set "TAG=%~1"
-shift
-goto parse_args
+if "%TAG%"=="--help" goto help
+if "%TAG%"=="-h" goto help
+
+if "%~2"=="" goto args_done
+if not "%~2"=="--source" goto invalid_args
+if "%~3"=="" (
+    echo --source requires a workspace path. >&2
+    goto fail
+)
+if not "%~4"=="" goto invalid_args
+set "SOURCE_ROOT=%~3"
 
 :args_done
 for %%I in ("%SOURCE_ROOT%") do set "SOURCE_ROOT=%%~fI"

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -134,4 +134,7 @@ def test_upgrade_script_accepts_a_source_override_for_bootstrapping() -> None:
 def test_upgrade_scripts_exist_for_linux_macos_and_windows() -> None:
     assert UPGRADE_SH.is_file()
     assert UPGRADE_BAT.is_file()
-    assert "xcopy" in UPGRADE_BAT.read_text(encoding="utf-8").lower()
+    batch_script = UPGRADE_BAT.read_text(encoding="utf-8").lower()
+
+    assert "xcopy" in batch_script
+    assert "findstr /r /x" in batch_script

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -138,3 +138,4 @@ def test_upgrade_scripts_exist_for_linux_macos_and_windows() -> None:
 
     assert "xcopy" in batch_script
     assert "findstr /r /x" in batch_script
+    assert "shift" not in batch_script


### PR DESCRIPTION
## Summary

- replace the batch argument loop that cleared valid release tags
- retain the documented `vX.Y.Z [--source PATH]` calling convention
- lock the simpler parser shape in the upgrade-script contract test

## Validation

- 19 focused Python tests passed
- Ruff, Bash syntax, ShellCheck, and diff hygiene passed

## Root-Cause Receipt

- Failure: the first Windows fix accepted the pattern but logged an empty requested release
- Cause: the generic batch argument loop and `shift` lost the caller tag under real CMD
- Fix: direct positional parsing for the supported argument order
- Regression gate: Windows Setup Audit runs `scripts\upgrade.bat v0.2.0`
