### PR TITLE
fix: preserve Windows upgrade arguments

### DIFF
--- a/scripts/upgrade.bat
+++ b/scripts/upgrade.bat
@@ -6,26 +6,18 @@ set "UPSTREAM_API=https://api.github.com/repos/rcnsnr/job-search-workflow/releas
 set "SCRIPT_DIR=%~dp0"
 for %%I in ("%SCRIPT_DIR%..") do set "DEFAULT_SOURCE_ROOT=%%~fI"
 set "SOURCE_ROOT=%DEFAULT_SOURCE_ROOT%"
-set "TAG="
-
-:parse_args
-if "%~1"=="" goto args_done
-if "%~1"=="--help" goto help
-if "%~1"=="-h" goto help
-if "%~1"=="--source" (
-    if "%~2"=="" (
-        echo --source requires a workspace path. >&2
-        goto fail
-    )
-    set "SOURCE_ROOT=%~2"
-    shift
-    shift
-    goto parse_args
-)
-if not "%TAG%"=="" goto invalid_args
 set "TAG=%~1"
-shift
-goto parse_args
+if "%TAG%"=="--help" goto help
+if "%TAG%"=="-h" goto help
+
+if "%~2"=="" goto args_done
+if not "%~2"=="--source" goto invalid_args
+if "%~3"=="" (
+    echo --source requires a workspace path. >&2
+    goto fail
+)
+if not "%~4"=="" goto invalid_args
+set "SOURCE_ROOT=%~3"
 
 :args_done
 for %%I in ("%SOURCE_ROOT%") do set "SOURCE_ROOT=%%~fI"

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -138,3 +138,4 @@ def test_upgrade_scripts_exist_for_linux_macos_and_windows() -> None:
 
     assert "xcopy" in batch_script
     assert "findstr /r /x" in batch_script
+    assert "shift" not in batch_script


### PR DESCRIPTION
## Summary

- replace the batch argument loop that cleared valid release tags
- retain the documented `vX.Y.Z [--source PATH]` calling convention
- lock the simpler parser shape in the upgrade-script contract test

## Validation

- 19 focused Python tests passed
- Ruff and diff hygiene passed

## Root-Cause Receipt

- Failure: Windows Setup Audit logged an empty requested release for `v0.2.0`
- Cause: the generic batch argument loop and `shift` lost the caller tag under real CMD
- Fix: direct positional parsing for the supported argument order
- Regression gate: Windows Setup Audit runs `scripts\upgrade.bat v0.2.0`
